### PR TITLE
Sandbox must be set to false by default

### DIFF
--- a/src/CheckoutApi.php
+++ b/src/CheckoutApi.php
@@ -285,7 +285,7 @@ final class CheckoutApi
 
         $defaults = array(static::CONFIG_SECRET         => '',
                           static::CONFIG_PUBLIC         => '',
-                          CheckoutConfiguration::ENVIRONMENT_SANDBOX => true);
+                          CheckoutConfiguration::ENVIRONMENT_SANDBOX => false);
 
         $this->safelyArrayMerge(static::CONFIG_SECTION_CHANNEL, $defaults, $configs);
 


### PR DESCRIPTION
It's not possible to set sandbox to `false` if it's not default with the current configuration.

This code can only set sandbox to `true`. `-1` should either set `sandbox` to `false` or the default value of `CheckoutConfiguration::ENVIRONMENT_SANDBOX` has to be false. Else there is no way to get out of the sandbox!
```
        if ($sandbox !== -1) { // Override environment
            $defaults[CheckoutConfiguration::ENVIRONMENT_SANDBOX] = (bool) $sandbox;
        }
```