### PR TITLE
Fix for webhook update error. Include the body when creating put and …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "checkout/checkout-sdk-php",
     "description": "Checkout.com SDK for PHP",
     "homepage": "https://github.com/checkout/checkout-sdk-php",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "type": "library",
     "license": "MIT",
     "keywords": ["checkout.com","payment","gateway","checkout","checkoutcom","GW3","CKO", "Reboot", "SDK", "Library", "PHP", "API"],

--- a/src/CheckoutApi.php
+++ b/src/CheckoutApi.php
@@ -47,7 +47,7 @@ final class CheckoutApi
      *
      * @var string
      */
-    const VERSION = '1.0.9';
+    const VERSION = '1.0.10';
 
     /**
      * Channel section.

--- a/src/Controllers/WebhookController.php
+++ b/src/Controllers/WebhookController.php
@@ -121,8 +121,17 @@ class WebhookController extends Controller
         unset($body[static::FIELD_ID]); // Remove ID from the body.
         $response = $this->requestAPI($webhook->getEndpoint())
             ->setBody($body);
+        
+        $response = $this->response($response, Webhook::QUALIFIED_NAME, $mode);
 
-        return $this->response($response, Webhook::QUALIFIED_NAME, $mode);
+        if (isset($response->headers)) {
+            $headers = new WebhookHeaders();
+            foreach ($response->headers as $header => $value) {
+                $headers->{lcfirst($header)} = $value;
+            }
+            $response->headers = $headers;
+        }
+        return $response;
     }
 
     /**
@@ -164,7 +173,16 @@ class WebhookController extends Controller
             ->setBody($body)
             ->setMethod($partially ? HttpHandler::METHOD_PATCH : HttpHandler::METHOD_PUT);
 
-        return $this->response($response, Webhook::QUALIFIED_NAME, $mode);
+        $response = $this->response($response, Webhook::QUALIFIED_NAME, $mode);
+
+        if (isset($response->headers)) {
+            $headers = new WebhookHeaders();
+            foreach ($response->headers as $header => $value) {
+                $headers->{lcfirst($header)} = $value;
+            }
+            $response->headers = $headers;
+        }
+        return $response;
     }
 
     /**

--- a/src/Library/HttpHandler.php
+++ b/src/Library/HttpHandler.php
@@ -345,7 +345,7 @@ class HttpHandler
         }
 
         // Set Body
-        if ($this->method === static::METHOD_POST) {
+        if ($this->method === static::METHOD_POST || $this->method === static::METHOD_PUT || $this->method === static::METHOD_PATCH) {
             curl_setopt($curl, CURLOPT_POSTFIELDS, $this->body);
         }
     }


### PR DESCRIPTION
…patch curl requests. When registering or updating a webhook the headers returned are now an instance of WebhookHeaders allowing you to update a registered webhook.