### PR TITLE
Add Multibanco payment source model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "checkout/checkout-sdk-php",
     "description": "Checkout.com SDK for PHP",
     "homepage": "https://github.com/checkout/checkout-sdk-php",
-    "version": "1.0.18",
+    "version": "1.0.19",
     "type": "library",
     "license": "MIT",
     "keywords": [

--- a/src/CheckoutApi.php
+++ b/src/CheckoutApi.php
@@ -48,7 +48,7 @@ class CheckoutApi
      *
      * @var string
      */
-    const VERSION = '1.0.18';
+    const VERSION = '1.0.19';
 
     /**
      * Channel section.

--- a/src/Models/Payments/MultibancoSource.php
+++ b/src/Models/Payments/MultibancoSource.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Checkout.com
+ * Authorised and regulated as an electronic money institution
+ * by the UK Financial Conduct Authority (FCA) under number 900816.
+ *
+ * PHP version 7
+ *
+ * @category  SDK
+ * @package   Checkout.com
+ * @author    Platforms Development Team <platforms@checkout.com>
+ * @copyright 2010-2019 Checkout.com
+ * @license   https://opensource.org/licenses/mit-license.html MIT License
+ * @link      https://docs.checkout.com/
+ */
+
+namespace Checkout\Models\Payments;
+
+/**
+ * Payment method Multibanco.
+ *
+ * @category SDK
+ * @package  Checkout.com
+ * @author   Platforms Development Team <platforms@checkout.com>
+ * @license  https://opensource.org/licenses/mit-license.html MIT License
+ * @link     https://docs.checkout.com/
+ */
+class MultibancoSource extends Source
+{
+
+    /**
+     * Qualified name of the class.
+     *
+     * @var string
+     */
+    const QUALIFIED_NAME = __CLASS__;
+
+    /**
+     * Name of the model.
+     *
+     * @var string
+     */
+    const MODEL_NAME = 'multibanco';
+
+
+    /**
+     * Magic Methods
+     */
+
+    /**
+     * Initialise Multibanco source.
+     *
+     * @param string $integrationType   The type of integration. Either direct or redirect.
+     * @param string $country           The billing country.
+     * @param object $payer             The payer.
+     * @param string $description       A description of the order.
+     */
+    public function __construct($country, $name, $descriptor = '')
+    {
+        $this->type = static::MODEL_NAME;
+        $this->payment_country = $country;
+        $this->account_holder_name = $name;
+        $this->billing_descriptor = $descriptor;
+    }
+}

--- a/tests/Models/Payments/MultibancoSourceTest.php
+++ b/tests/Models/Payments/MultibancoSourceTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Checkout\tests\Models\Payments;
+
+use Checkout\Models\Payments\MultibancoSource;
+use Checkout\Models\Payments\Payer;
+use PHPUnit\Framework\TestCase;
+
+class MultibancoSourceTest extends TestCase
+{
+    public function testCreate()
+    {
+        $model = new MultibancoSource('{country}', new Payer('{name}', '{email}', '{document}'));
+        $this->assertEquals($model::MODEL_NAME, $model->type);
+    }
+}


### PR DESCRIPTION
Multibanco payment source model is now available:

```
$method = new MultibancoSource('PT', 'Miguel Estrada', 'Billing Descriptor');
$payment = new Checkout\Models\Payments\Payment($method, 'EUR');
$payment->amount = 999; // = 9.99
$response = $checkout
        ->payments()
        ->request($payment);
```
