### PR TITLE
Minor fixes in APM clients

### DIFF
--- a/lib/Checkout/Apm/Klarna/Klarna.php
+++ b/lib/Checkout/Apm/Klarna/Klarna.php
@@ -10,7 +10,7 @@ class Klarna
     public array $products;
 
     //KlarnaShippingInfo
-    public array $shippingInfo;
+    public array $shipping_info;
 
     public int $shipping_delay;
 }

--- a/lib/Checkout/Apm/Klarna/OrderCaptureRequest.php
+++ b/lib/Checkout/Apm/Klarna/OrderCaptureRequest.php
@@ -17,7 +17,7 @@ class OrderCaptureRequest
 
     public string $reference;
 
-    public array $Metadata;
+    public array $metadata;
 
     public Klarna $klarna;
 

--- a/test/Checkout/Tests/Apm/Ideal/IdealIntegrationTest.php
+++ b/test/Checkout/Tests/Apm/Ideal/IdealIntegrationTest.php
@@ -23,7 +23,6 @@ class IdealIntegrationTest extends SandboxTestFixture
      */
     public function shouldGetInfo(): void
     {
-        $this->markTestSkipped("unavailable");
         $response = $this->defaultApi->getIdealClient()->getInfo();
         $this->assertResponse($response,
             "_links",

--- a/test/Checkout/Tests/Apm/Klarna/KlarnaIntegrationTest.php
+++ b/test/Checkout/Tests/Apm/Klarna/KlarnaIntegrationTest.php
@@ -41,7 +41,7 @@ class KlarnaIntegrationTest extends SandboxTestFixture
         $creditSessionRequest->locale = "en-GB";
         $creditSessionRequest->amount = 1000;
         $creditSessionRequest->tax_amount = 1;
-        $creditSessionRequest->products = array($klarnaProduct);;
+        $creditSessionRequest->products = array($klarnaProduct);
 
         $creditSessionResponse = $this->defaultApi->getKlarnaClient()->createCreditSession($creditSessionRequest);
 


### PR DESCRIPTION
This commit fixes a few typos found in the module `apm`. iDEAL `shouldGetInfo` integration test was re-enabled as this operation seems to be available again in sandbox