### PR TITLE
Improve exception handling

### DIFF
--- a/lib/Checkout/ApiClient.php
+++ b/lib/Checkout/ApiClient.php
@@ -5,7 +5,7 @@ namespace Checkout;
 use Checkout\Common\AbstractQueryFilter;
 use Checkout\Files\FileRequest;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -166,8 +166,8 @@ class ApiClient
             return json_decode($response->getBody(), true);
         } catch (Throwable $e) {
             $this->logger->error($path . " error: " . $e->getMessage());
-            if ($e instanceof ClientException) {
-                throw new CheckoutApiException("The API response status code (" . $e->getCode() . ") does not indicate success.");
+            if ($e instanceof RequestException) {
+                throw CheckoutApiException::from($e);
             }
             throw new CheckoutApiException($e);
         }
@@ -194,8 +194,8 @@ class ApiClient
             ]);
         } catch (Throwable $e) {
             $this->logger->error($path . " error: " . $e->getMessage());
-            if ($e instanceof ClientException) {
-                throw new CheckoutApiException("The API response status code (" . $e->getCode() . ") does not indicate success.");
+            if ($e instanceof RequestException) {
+                throw CheckoutApiException::from($e);
             }
             throw new CheckoutApiException($e);
         }
@@ -205,7 +205,6 @@ class ApiClient
     {
         return $this->baseUri . $path;
     }
-
 
     /**
      * @param SdkAuthorization $authorization

--- a/lib/Checkout/CheckoutApiException.php
+++ b/lib/Checkout/CheckoutApiException.php
@@ -2,12 +2,28 @@
 
 namespace Checkout;
 
+use GuzzleHttp\Exception\RequestException;
+
 class CheckoutApiException extends CheckoutException
 {
+
+    public ?string $request_id;
+    public int $http_status_code;
+    public ?array $error_details;
 
     public function __construct(string $message)
     {
         parent::__construct($message);
+    }
+
+    public static function from(RequestException $requestException): CheckoutApiException
+    {
+        $body = json_decode($requestException->getResponse()->getBody()->getContents(), true);
+        $ex = new CheckoutApiException("The API response status code (" . $requestException->getCode() . ") does not indicate success.");
+        $ex->request_id = $body != null ? $body["request_id"] : null;
+        $ex->http_status_code = $requestException->getCode();
+        $ex->error_details = $body;
+        return $ex;
     }
 
 }

--- a/test/Checkout/Tests/CheckoutDefaultSdkTest.php
+++ b/test/Checkout/Tests/CheckoutDefaultSdkTest.php
@@ -6,7 +6,7 @@ use Checkout\CheckoutArgumentException;
 use Checkout\CheckoutDefaultSdk;
 use Checkout\Environment;
 use Checkout\HttpClientBuilderInterface;
-use Exception;
+use Throwable;
 
 class CheckoutDefaultSdkTest extends UnitTestFixture
 {
@@ -40,7 +40,7 @@ class CheckoutDefaultSdkTest extends UnitTestFixture
             $builder->setEnvironment(Environment::sandbox());
             $this->assertNotNull($builder->build());
             self::fail();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             self::assertTrue($e instanceof CheckoutArgumentException);
             self::assertEquals("invalid public key", $e->getMessage());
         }
@@ -52,7 +52,7 @@ class CheckoutDefaultSdkTest extends UnitTestFixture
             $builder->setEnvironment(Environment::sandbox());
             $this->assertNotNull($builder->build());
             self::fail();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             self::assertTrue($e instanceof CheckoutArgumentException);
             self::assertEquals("invalid secret key", $e->getMessage());
         }

--- a/test/Checkout/Tests/CheckoutFourSdkTest.php
+++ b/test/Checkout/Tests/CheckoutFourSdkTest.php
@@ -7,6 +7,7 @@ use Checkout\CheckoutFourSdk;
 use Checkout\Environment;
 use Checkout\HttpClientBuilderInterface;
 use Exception;
+use Throwable;
 
 class CheckoutFourSdkTest extends UnitTestFixture
 {
@@ -52,7 +53,7 @@ class CheckoutFourSdkTest extends UnitTestFixture
             $builder->setEnvironment(Environment::sandbox());
             $this->assertNotNull($builder->build());
             self::fail();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             self::assertTrue($e instanceof CheckoutArgumentException);
             self::assertEquals("invalid secret key", $e->getMessage());
         }

--- a/test/Checkout/Tests/Instruments/InstrumentsIntegrationTest.php
+++ b/test/Checkout/Tests/Instruments/InstrumentsIntegrationTest.php
@@ -14,7 +14,6 @@ use Checkout\Instruments\UpdateInstrumentRequest;
 use Checkout\PlatformType;
 use Checkout\Tests\SandboxTestFixture;
 use Checkout\Tokens\CardTokenRequest;
-use Exception;
 
 class InstrumentsIntegrationTest extends SandboxTestFixture
 {
@@ -100,7 +99,7 @@ class InstrumentsIntegrationTest extends SandboxTestFixture
         try {
             $this->defaultApi->getInstrumentsClient()->delete($instrument["id"]);
             self::fail("shouldn't get here!");
-        } catch (Exception $e) {
+        } catch (CheckoutApiException $e) {
             self::assertEquals(self::MESSAGE_404, $e->getMessage());
         }
 

--- a/test/Checkout/Tests/OAuthIntegrationTest.php
+++ b/test/Checkout/Tests/OAuthIntegrationTest.php
@@ -13,7 +13,7 @@ use Checkout\Payments\Four\Request\PaymentRequest;
 use Checkout\Payments\Four\Request\Source\RequestCardSource;
 use Checkout\Payments\Four\Sender\PaymentIndividualSender;
 use Checkout\PlatformType;
-use Exception;
+use Throwable;
 
 class OAuthIntegrationTest extends SandboxTestFixture
 {
@@ -85,7 +85,7 @@ class OAuthIntegrationTest extends SandboxTestFixture
             $builder->setFilesEnvironment(Environment::sandbox());
             $this->fourApi = $builder->build();
             self::fail("shouldn't get here");
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->assertEquals("Client error: `POST https://access.sandbox.checkout.com/connect/token` resulted in a `400 Bad Request` response:\n{\"error\":\"invalid_client\"}\n", $e->getMessage());
         }
 
@@ -104,7 +104,7 @@ class OAuthIntegrationTest extends SandboxTestFixture
             $builder->setFilesEnvironment(Environment::sandbox());
             $this->fourApi = $builder->build();
             self::fail("shouldn't get here");
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->assertEquals("cURL error 6: Could not resolve host: test.checkout.com (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://test.checkout.com", $e->getMessage());
         }
 

--- a/test/Checkout/Tests/Payments/RefundPaymentsIntegrationTest.php
+++ b/test/Checkout/Tests/Payments/RefundPaymentsIntegrationTest.php
@@ -19,7 +19,7 @@ class RefundPaymentsIntegrationTest extends AbstractPaymentsIntegrationTest
         $refundRequest = new RefundRequest();
         $refundRequest->reference = uniqid();
 
-        $response = self::retriable(fn() => $this->defaultApi->getPaymentsClient()->refundPayment($paymentResponse["id"]));
+        $response = self::retriable(fn() => $this->defaultApi->getPaymentsClient()->refundPayment($paymentResponse["id"], $refundRequest));
 
         $this->assertResponse($response,
             "action_id",

--- a/test/Checkout/Tests/Payments/RequestApmPaymentsIntegrationTest.php
+++ b/test/Checkout/Tests/Payments/RequestApmPaymentsIntegrationTest.php
@@ -2,7 +2,6 @@
 
 namespace Checkout\Tests\Payments;
 
-use Checkout\CheckoutApiException;
 use Checkout\Common\Country;
 use Checkout\Common\Currency;
 use Checkout\Payments\PaymentRequest;

--- a/test/Checkout/Tests/SandboxTestFixture.php
+++ b/test/Checkout/Tests/SandboxTestFixture.php
@@ -9,10 +9,11 @@ use Checkout\CheckoutFourSdk;
 use Checkout\Environment;
 use Checkout\Four\FourOAuthScope;
 use Checkout\PlatformType;
+use Exception;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\Exception;
 use Psr\Log\LoggerInterface;
 use function PHPUnit\Framework\assertNotEmpty;
 use function PHPUnit\Framework\assertNotNull;
@@ -122,13 +123,13 @@ abstract class SandboxTestFixture extends TestCase
                 if ($predicate($response)) {
                     return $response;
                 }
-            } catch (\Exception $ex) {
+            } catch (Exception $ex) {
                 $this->logger->warning("Request/Predicate failed with error '${ex}' - retry ${currentAttempt}/${maxAttempts}");
             }
             $currentAttempt++;
             sleep(2);
         }
-        throw new Exception("Max attempts reached!");
+        throw new AssertionFailedError("Max attempts reached!");
     }
 
 }

--- a/test/Checkout/Tests/Sessions/CompleteSessionsIntegrationTest.php
+++ b/test/Checkout/Tests/Sessions/CompleteSessionsIntegrationTest.php
@@ -23,17 +23,16 @@ class CompleteSessionsIntegrationTest extends AbstractSessionsIntegrationTest
         try {
             $this->fourApi->getSessionsClient()->completeSession($sessionId);
             self::fail("shouldn't get here!");
-        } catch (\Exception $e) {
+        } catch (CheckoutApiException $e) {
             self::assertEquals(self::MESSAGE_403, $e->getMessage());
         }
 
         try {
             $this->fourApi->getSessionsClient()->completeSession($sessionId, $sessionSecret);
             self::fail("shouldn't get here!");
-        } catch (\Exception $e) {
+        } catch (CheckoutApiException $e) {
             self::assertEquals(self::MESSAGE_403, $e->getMessage());
         }
-
 
     }
 }

--- a/test/Checkout/Tests/Webhooks/WebhooksIntegrationTest.php
+++ b/test/Checkout/Tests/Webhooks/WebhooksIntegrationTest.php
@@ -2,10 +2,10 @@
 
 namespace Checkout\Tests\Webhooks;
 
+use Checkout\CheckoutApiException;
 use Checkout\PlatformType;
 use Checkout\Tests\SandboxTestFixture;
 use Checkout\Webhooks\WebhookRequest;
-use Exception;
 
 class WebhooksIntegrationTest extends SandboxTestFixture
 {
@@ -84,7 +84,7 @@ class WebhooksIntegrationTest extends SandboxTestFixture
         try {
             $this->defaultApi->getWebhooksClient()->retrieveWebhook($webhookId);
             self::fail("shouldn't get here!");
-        } catch (Exception $e) {
+        } catch (CheckoutApiException $e) {
             self::assertEquals(self::MESSAGE_404, $e->getMessage());
         }
 


### PR DESCRIPTION
This commit improves `CheckoutApiException` by parsing possible `RequestException` and setting values such as `$request_id`, `$http_status_code` and `$error_details` (body).