### PR TITLE
Improve static keys validation

### DIFF
--- a/lib/Checkout/Four/FourStaticKeysCheckoutSdkBuilder.php
+++ b/lib/Checkout/Four/FourStaticKeysCheckoutSdkBuilder.php
@@ -3,6 +3,7 @@
 namespace Checkout\Four;
 
 use Checkout\AbstractStaticKeysCheckoutSdkBuilder;
+use Checkout\CheckoutArgumentException;
 use Checkout\CheckoutConfiguration;
 use Checkout\SdkCredentialsInterface;
 
@@ -13,13 +14,11 @@ class FourStaticKeysCheckoutSdkBuilder extends AbstractStaticKeysCheckoutSdkBuil
 
     public function setPublicKey($publicKey)
     {
-        $this->validatePublicKey($publicKey, self::PUBLIC_KEY_PATTERN);
         $this->publicKey = $publicKey;
     }
 
     public function setSecretKey($secretKey)
     {
-        $this->validateSecretKey($secretKey, self::SECRET_KEY_PATTERN);
         $this->secretKey = $secretKey;
     }
 
@@ -33,9 +32,12 @@ class FourStaticKeysCheckoutSdkBuilder extends AbstractStaticKeysCheckoutSdkBuil
 
     /**
      * @return CheckoutApi
+     * @throws CheckoutArgumentException
      */
     public function build()
     {
+        $this->validatePublicKey($this->publicKey, self::PUBLIC_KEY_PATTERN);
+        $this->validateSecretKey($this->secretKey, self::SECRET_KEY_PATTERN);
         $configuration = new CheckoutConfiguration($this->getSdkCredentials(), $this->environment, $this->httpClientBuilder, $this->logger);
         return new CheckoutApi($configuration);
     }

--- a/lib/Checkout/StaticKeysCheckoutSdkBuilder.php
+++ b/lib/Checkout/StaticKeysCheckoutSdkBuilder.php
@@ -10,13 +10,11 @@ class StaticKeysCheckoutSdkBuilder extends AbstractStaticKeysCheckoutSdkBuilder
 
     public function setPublicKey($publicKey)
     {
-        $this->validatePublicKey($publicKey, self::PUBLIC_KEY_PATTERN);
         $this->publicKey = $publicKey;
     }
 
     public function setSecretKey($secretKey)
     {
-        $this->validateSecretKey($secretKey, self::SECRET_KEY_PATTERN);
         $this->secretKey = $secretKey;
     }
 
@@ -30,9 +28,12 @@ class StaticKeysCheckoutSdkBuilder extends AbstractStaticKeysCheckoutSdkBuilder
 
     /**
      * @return CheckoutApi
+     * @throws CheckoutArgumentException
      */
     public function build()
     {
+        $this->validatePublicKey($this->publicKey, self::PUBLIC_KEY_PATTERN);
+        $this->validateSecretKey($this->secretKey, self::SECRET_KEY_PATTERN);
         $configuration = new CheckoutConfiguration($this->getSdkCredentials(), $this->environment, $this->httpClientBuilder, $this->logger);
         $apiClient = new ApiClient($configuration);
         return new CheckoutApi($apiClient, $configuration);

--- a/test/Checkout/Tests/SandboxTestFixture.php
+++ b/test/Checkout/Tests/SandboxTestFixture.php
@@ -67,7 +67,7 @@ abstract class SandboxTestFixture extends TestCase
 
     }
 
-    protected function assertResponse($obj, ...$properties) // @phpstan-ignore-line
+    protected function assertResponse($obj, ...$properties)
     {
         $this->assertNotNull($obj);
         $this->assertNotEmpty($properties);


### PR DESCRIPTION
This commit changes the validation strategy to validate both keys on build time to avoid missing validation when some or both keys are not set during instantiation.