### PR TITLE
Added hint support to all objects in SDK

### DIFF
--- a/lib/Checkout/AbstractCheckoutSdkBuilder.php
+++ b/lib/Checkout/AbstractCheckoutSdkBuilder.php
@@ -20,21 +20,33 @@ abstract class AbstractCheckoutSdkBuilder
         $this->setDefaultLogger();
     }
 
+    /**
+     * @param Environment $environment
+     */
     public function setEnvironment(Environment $environment)
     {
         $this->environment = $environment;
     }
 
+    /**
+     * @param HttpClientBuilderInterface $httpClientBuilder
+     */
     public function setHttpClientBuilder(HttpClientBuilderInterface $httpClientBuilder)
     {
         $this->httpClientBuilder = $httpClientBuilder;
     }
 
+    /**
+     * @param LoggerInterface $logger
+     */
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }
 
+    /**
+     * @return CheckoutConfiguration
+     */
     protected function getCheckoutConfiguration()
     {
         return new CheckoutConfiguration(

--- a/lib/Checkout/AbstractStaticKeysCheckoutSdkBuilder.php
+++ b/lib/Checkout/AbstractStaticKeysCheckoutSdkBuilder.php
@@ -8,12 +8,9 @@ abstract class AbstractStaticKeysCheckoutSdkBuilder extends AbstractCheckoutSdkB
     protected $publicKey = null;
     protected $secretKey = null;
 
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     /**
+     * @param string $key
+     * @param string $secretKeyPattern
      * @throws CheckoutArgumentException
      */
     protected function validateSecretKey($key, $secretKeyPattern)
@@ -25,6 +22,8 @@ abstract class AbstractStaticKeysCheckoutSdkBuilder extends AbstractCheckoutSdkB
     }
 
     /**
+     * @param string $key
+     * @param string $publicKeyPattern
      * @throws CheckoutArgumentException
      */
     protected function validatePublicKey($key, $publicKeyPattern)

--- a/lib/Checkout/ApiClient.php
+++ b/lib/Checkout/ApiClient.php
@@ -199,6 +199,10 @@ class ApiClient
         }
     }
 
+    /**
+     * @param string $path
+     * @return string
+     */
     private function getRequestUrl($path)
     {
         return $this->baseUri . $path;

--- a/lib/Checkout/Apm/CheckoutApmApi.php
+++ b/lib/Checkout/Apm/CheckoutApmApi.php
@@ -26,19 +26,27 @@ class CheckoutApmApi
         $this->sepaClient = new SepaClient($apiClient, $configuration);
     }
 
+    /**
+     * @return IdealClient
+     */
     public function getIdealClient()
     {
         return $this->idealClient;
     }
 
+    /**
+     * @return KlarnaClient
+     */
     public function getKlarnaClient()
     {
         return $this->klarnaClient;
     }
 
+    /**
+     * @return SepaClient
+     */
     public function getSepaClient()
     {
         return $this->sepaClient;
     }
-
 }

--- a/lib/Checkout/Apm/Klarna/CreditSessionRequest.php
+++ b/lib/Checkout/Apm/Klarna/CreditSessionRequest.php
@@ -2,18 +2,38 @@
 
 namespace Checkout\Apm\Klarna;
 
+use Checkout\Common\Country;
+use Checkout\Common\Currency;
+
 class CreditSessionRequest
 {
+    /**
+     * @var Country
+     */
     public $purchase_country;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
+    /**
+     * @var string
+     */
     public $locale;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var int
+     */
     public $tax_amount;
 
-    //KlarnaProduct
+    /**
+     * @var array of KlarnaProduct
+     */
     public $products;
 }

--- a/lib/Checkout/Apm/Klarna/Klarna.php
+++ b/lib/Checkout/Apm/Klarna/Klarna.php
@@ -4,13 +4,23 @@ namespace Checkout\Apm\Klarna;
 
 class Klarna
 {
+    /**
+     * @var string
+     */
     public $description;
 
-    //KlarnaProduct
+    /**
+     * @var array of KlarnaProduct
+     */
     public $products;
 
-    //KlarnaShippingInfo
+    /**
+     * @var array of KlarnaShippingInfo
+     */
     public $shipping_info;
 
+    /**
+     * @var int
+     */
     public $shipping_delay;
 }

--- a/lib/Checkout/Apm/Klarna/KlarnaProduct.php
+++ b/lib/Checkout/Apm/Klarna/KlarnaProduct.php
@@ -4,15 +4,33 @@ namespace Checkout\Apm\Klarna;
 
 class KlarnaProduct
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var int
+     */
     public $quantity;
 
+    /**
+     * @var int
+     */
     public $unit_price;
 
+    /**
+     * @var int
+     */
     public $tax_rate;
 
+    /**
+     * @var int
+     */
     public $total_amount;
 
+    /**
+     * @var int
+     */
     public $total_tax_amount;
 }

--- a/lib/Checkout/Apm/Klarna/KlarnaShippingInfo.php
+++ b/lib/Checkout/Apm/Klarna/KlarnaShippingInfo.php
@@ -4,17 +4,38 @@ namespace Checkout\Apm\Klarna;
 
 class KlarnaShippingInfo
 {
+    /**
+     * @var string
+     */
     public $shipping_company;
 
+    /**
+     * @var string
+     */
     public $shipping_method;
 
+    /**
+     * @var string
+     */
     public $tracking_number;
 
+    /**
+     * @var string
+     */
     public $tracking_uri;
 
+    /**
+     * @var string
+     */
     public $return_shipping_company;
 
+    /**
+     * @var string
+     */
     public $return_tracking_number;
 
+    /**
+     * @var string
+     */
     public $return_tracking_uri;
 }

--- a/lib/Checkout/Apm/Klarna/OrderCaptureRequest.php
+++ b/lib/Checkout/Apm/Klarna/OrderCaptureRequest.php
@@ -11,20 +11,38 @@ class OrderCaptureRequest
         $this->type = PaymentSourceType::$klarna;
     }
 
+    /**
+     * @var PaymentSourceType
+     */
     public $type;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var int
+     */
     public $reference;
 
+    /**
+     * @var array
+     */
     public $metadata;
 
-    // Klarna
+    /**
+     * @var Klarna
+     */
     public $klarna;
 
-    // KlarnaShippingInfo
+    /**
+     * @var KlarnaShippingInfo
+     */
     public $shipping_info;
 
+    /**
+     * @var int
+     */
     public $shipping_delay;
-
 }

--- a/lib/Checkout/CheckoutApi.php
+++ b/lib/Checkout/CheckoutApi.php
@@ -48,61 +48,97 @@ final class CheckoutApi extends CheckoutApmApi
         $this->reconciliationClient = new ReconciliationClient($apiClient, $configuration);
     }
 
+    /**
+     * @return SourcesClient
+     */
     public function getSourcesClient()
     {
         return $this->sourcesClient;
     }
 
+    /**
+     * @return TokensClient
+     */
     public function getTokensClient()
     {
         return $this->tokensClient;
     }
 
+    /**
+     * @return InstrumentsClient
+     */
     public function getInstrumentsClient()
     {
         return $this->instrumentsClient;
     }
 
+    /**
+     * @return WebhooksClient
+     */
     public function getWebhooksClient()
     {
         return $this->webhooksClient;
     }
 
+    /**
+     * @return EventsClient
+     */
     public function getEventsClient()
     {
         return $this->eventsClient;
     }
 
+    /**
+     * @return PaymentsClient
+     */
     public function getPaymentsClient()
     {
         return $this->paymentsClient;
     }
 
+    /**
+     * @return CustomersClient
+     */
     public function getCustomersClient()
     {
         return $this->customersClient;
     }
 
+    /**
+     * @return DisputesClient
+     */
     public function getDisputesClient()
     {
         return $this->disputesClient;
     }
 
+    /**
+     * @return PaymentLinksClient
+     */
     public function getPaymentLinksClient()
     {
         return $this->paymentLinksClient;
     }
 
+    /**
+     * @return HostedPaymentsClient
+     */
     public function getHostedPaymentsClient()
     {
         return $this->hostedPaymentsClient;
     }
 
+    /**
+     * @return RiskClient
+     */
     public function getRiskClient()
     {
         return $this->riskClient;
     }
 
+    /**
+     * @return ReconciliationClient
+     */
     public function getReconciliationClient()
     {
         return $this->reconciliationClient;

--- a/lib/Checkout/CheckoutApiException.php
+++ b/lib/Checkout/CheckoutApiException.php
@@ -11,11 +11,10 @@ class CheckoutApiException extends CheckoutException
     public $http_status_code;
     public $error_details;
 
-    public function __construct($message)
-    {
-        parent::__construct($message);
-    }
-
+    /**
+     * @param RequestException $requestException
+     * @return CheckoutApiException
+     */
     public static function from(RequestException $requestException)
     {
         $body = json_decode($requestException->getResponse()->getBody()->getContents(), true);
@@ -25,5 +24,4 @@ class CheckoutApiException extends CheckoutException
         $ex->error_details = $body;
         return $ex;
     }
-
 }

--- a/lib/Checkout/CheckoutAuthorizationException.php
+++ b/lib/Checkout/CheckoutAuthorizationException.php
@@ -6,15 +6,6 @@ class CheckoutAuthorizationException extends CheckoutException
 {
 
     /**
-     * @param $message
-     */
-    public function __construct($message)
-    {
-        parent::__construct($message);
-    }
-
-
-    /**
      * @param $authorizationType
      * @return CheckoutAuthorizationException
      */
@@ -47,5 +38,4 @@ class CheckoutAuthorizationException extends CheckoutException
     {
         return new CheckoutAuthorizationException($keyType . "  is required for this operation");
     }
-
 }

--- a/lib/Checkout/CheckoutConfiguration.php
+++ b/lib/Checkout/CheckoutConfiguration.php
@@ -14,6 +14,12 @@ final class CheckoutConfiguration
 
     private $logger;
 
+    /**
+     * @param SdkCredentialsInterface $sdkCredentials
+     * @param Environment $environment
+     * @param HttpClientBuilderInterface $httpClientBuilder
+     * @param LoggerInterface $logger
+     */
     public function __construct(
         SdkCredentialsInterface    $sdkCredentials,
         Environment                $environment,
@@ -26,21 +32,33 @@ final class CheckoutConfiguration
         $this->logger = $logger;
     }
 
+    /**
+     * @return SdkCredentialsInterface
+     */
     public function getSdkCredentials()
     {
         return $this->sdkCredentials;
     }
 
+    /**
+     * @return Environment
+     */
     public function getEnvironment()
     {
         return $this->environment;
     }
 
+    /**
+     * @return HttpClientBuilderInterface
+     */
     public function getHttpClientBuilder()
     {
         return $this->httpClientBuilder;
     }
 
+    /**
+     * @return LoggerInterface
+     */
     public function getLogger()
     {
         return $this->logger;

--- a/lib/Checkout/CheckoutFourSdk.php
+++ b/lib/Checkout/CheckoutFourSdk.php
@@ -8,11 +8,17 @@ use Checkout\Four\FourStaticKeysCheckoutSdkBuilder;
 class CheckoutFourSdk
 {
 
+    /**
+     * @return FourStaticKeysCheckoutSdkBuilder
+     */
     public static function staticKeys()
     {
         return new FourStaticKeysCheckoutSdkBuilder();
     }
 
+    /**
+     * @return FourOAuthCheckoutSdkBuilder
+     */
     public static function oAuth()
     {
         return new FourOAuthCheckoutSdkBuilder();

--- a/lib/Checkout/CheckoutUtils.php
+++ b/lib/Checkout/CheckoutUtils.php
@@ -10,6 +10,10 @@ class CheckoutUtils
     const PROJECT_NAME = "checkout-sdk-php";
     const PROJECT_VERSION = "2.1.1";
 
+    /**
+     * @param DateTime $date
+     * @return string
+     */
     public static function formatDate(DateTime $date)
     {
         return $date->format("Y-m-d\TH:i:sO");

--- a/lib/Checkout/Client.php
+++ b/lib/Checkout/Client.php
@@ -10,6 +10,11 @@ abstract class Client
 
     private $sdkAuthorizationType;
 
+    /**
+     * @param ApiClient $apiClient
+     * @param CheckoutConfiguration $configuration
+     * @param $sdkAuthorizationType
+     */
     public function __construct(ApiClient $apiClient, CheckoutConfiguration $configuration, $sdkAuthorizationType)
     {
         $this->apiClient = $apiClient;
@@ -17,11 +22,18 @@ abstract class Client
         $this->sdkAuthorizationType = $sdkAuthorizationType;
     }
 
+    /**
+     * @return mixed
+     */
     protected function sdkAuthorization()
     {
         return $this->configuration->getSdkCredentials()->getAuthorization($this->sdkAuthorizationType);
     }
 
+    /**
+     * @param $authorizationType
+     * @return mixed
+     */
     protected function sdkSpecificAuthorization($authorizationType)
     {
         return $this->configuration->getSdkCredentials()->getAuthorization($authorizationType);
@@ -35,5 +47,4 @@ abstract class Client
     {
         return join("/", $parts);
     }
-
 }

--- a/lib/Checkout/Common/Address.php
+++ b/lib/Checkout/Common/Address.php
@@ -4,16 +4,33 @@ namespace Checkout\Common;
 
 class Address
 {
+    /**
+     * @var string
+     */
     public $address_line1;
 
+    /**
+     * @var string
+     */
     public $address_line2;
 
+    /**
+     * @var string
+     */
     public $city;
 
+    /**
+     * @var string
+     */
     public $state;
 
+    /**
+     * @var string
+     */
     public $zip;
 
+    /**
+     * @var Country
+     */
     public $country;
-
 }

--- a/lib/Checkout/Common/CustomerRequest.php
+++ b/lib/Checkout/Common/CustomerRequest.php
@@ -4,12 +4,23 @@ namespace Checkout\Common;
 
 class CustomerRequest
 {
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $email;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Common/Four/AccountHolder.php
+++ b/lib/Checkout/Common/Four/AccountHolder.php
@@ -2,16 +2,28 @@
 
 namespace Checkout\Common\Four;
 
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
+
 class AccountHolder
 {
+    /**
+     * @var string
+     */
     public $first_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Common/Four/BankDetails.php
+++ b/lib/Checkout/Common/Four/BankDetails.php
@@ -2,13 +2,22 @@
 
 namespace Checkout\Common\Four;
 
+use Checkout\Common\Address;
+
 class BankDetails
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $branch;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $address;
-
 }

--- a/lib/Checkout/Common/Four/Product.php
+++ b/lib/Checkout/Common/Four/Product.php
@@ -4,24 +4,53 @@ namespace Checkout\Common\Four;
 
 class Product
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var int
+     */
     public $quantity;
 
+    /**
+     * @var int
+     */
     public $unit_price;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var string
+     */
     public $image_url;
 
+    /**
+     * @var string
+     */
     public $url;
 
+    /**
+     * @var int
+     */
     public $total_amount;
 
+    /**
+     * @var int
+     */
     public $tax_amount;
 
+    /**
+     * @var int
+     */
     public $discount_amount;
 
+    /**
+     * @var string
+     */
     public $sku;
-
 }

--- a/lib/Checkout/Common/MarketplaceCommission.php
+++ b/lib/Checkout/Common/MarketplaceCommission.php
@@ -4,8 +4,13 @@ namespace Checkout\Common;
 
 class MarketplaceCommission
 {
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var int
+     */
     public $percentage;
-
 }

--- a/lib/Checkout/Common/MarketplaceData.php
+++ b/lib/Checkout/Common/MarketplaceData.php
@@ -4,9 +4,13 @@ namespace Checkout\Common;
 
 class MarketplaceData
 {
+    /**
+     * @var string
+     */
     public $sub_entity_id;
 
-    // array MarketplaceDataSubEntity
+    /**
+     * @var array of MarketplaceDataSubEntity
+     */
     public $sub_entities;
-
 }

--- a/lib/Checkout/Common/MarketplaceDataSubEntity.php
+++ b/lib/Checkout/Common/MarketplaceDataSubEntity.php
@@ -4,13 +4,23 @@ namespace Checkout\Common;
 
 class MarketplaceDataSubEntity
 {
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var string
+     */
     public $reference;
 
-    // MarketplaceCommission
+    /**
+     * @var MarketplaceCommission
+     */
     public $commission;
-
 }

--- a/lib/Checkout/Common/Phone.php
+++ b/lib/Checkout/Common/Phone.php
@@ -5,8 +5,13 @@ namespace Checkout\Common;
 class Phone
 {
 
+    /**
+     * @var string
+     */
     public $country_code;
 
+    /**
+     * @var string
+     */
     public $number;
-
 }

--- a/lib/Checkout/Common/Product.php
+++ b/lib/Checkout/Common/Product.php
@@ -4,10 +4,18 @@ namespace Checkout\Common;
 
 class Product
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var int
+     */
     public $quantity;
 
+    /**
+     * @var int
+     */
     public $price;
-
 }

--- a/lib/Checkout/Common/QueryFilterDateRange.php
+++ b/lib/Checkout/Common/QueryFilterDateRange.php
@@ -2,11 +2,17 @@
 
 namespace Checkout\Common;
 
+use DateTime;
+
 class QueryFilterDateRange extends AbstractQueryFilter
 {
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $from;
 
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $to;
 }

--- a/lib/Checkout/Customers/CustomerRequest.php
+++ b/lib/Checkout/Customers/CustomerRequest.php
@@ -2,13 +2,27 @@
 
 namespace Checkout\Customers;
 
+use Checkout\Common\Phone;
+
 class CustomerRequest
 {
+    /**
+     * @var string
+     */
     public $email;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var Phone
+     */
     public $phone;
 
+    /**
+     * @var array
+     */
     public $metadata;
 }

--- a/lib/Checkout/Customers/Four/CustomerRequest.php
+++ b/lib/Checkout/Customers/Four/CustomerRequest.php
@@ -4,6 +4,8 @@ namespace Checkout\Customers\Four;
 
 class CustomerRequest extends \Checkout\Customers\CustomerRequest
 {
-    // array
+    /**
+     * @var array of string
+     */
     public $instruments;
 }

--- a/lib/Checkout/DefaultHttpClientBuilder.php
+++ b/lib/Checkout/DefaultHttpClientBuilder.php
@@ -14,9 +14,11 @@ final class DefaultHttpClientBuilder implements HttpClientBuilderInterface
         $this->client = new GuzzleHttpClient();
     }
 
+    /**
+     * @return GuzzleHttpClient
+     */
     public function getClient()
     {
         return $this->client;
     }
-
 }

--- a/lib/Checkout/Disputes/DisputeEvidenceRequest.php
+++ b/lib/Checkout/Disputes/DisputeEvidenceRequest.php
@@ -4,35 +4,83 @@ namespace Checkout\Disputes;
 
 class DisputeEvidenceRequest
 {
+    /**
+     * @var string
+     */
     public $proof_of_delivery_or_service_file;
 
+    /**
+     * @var string
+     */
     public $proof_of_delivery_or_service_text;
 
+    /**
+     * @var string
+     */
     public $invoice_or_receipt_file;
 
+    /**
+     * @var string
+     */
     public $invoice_or_receipt_text;
 
+    /**
+     * @var string
+     */
     public $invoice_showing_distinct_transactions_file;
 
+    /**
+     * @var string
+     */
     public $invoice_showing_distinct_transactions_text;
 
+    /**
+     * @var string
+     */
     public $customer_communication_file;
 
+    /**
+     * @var string
+     */
     public $customer_communication_text;
 
+    /**
+     * @var string
+     */
     public $refund_or_cancellation_policy_file;
 
+    /**
+     * @var string
+     */
     public $refund_or_cancellation_policy_text;
 
+    /**
+     * @var string
+     */
     public $recurring_transaction_agreement_file;
 
+    /**
+     * @var string
+     */
     public $recurring_transaction_agreement_text;
 
+    /**
+     * @var string
+     */
     public $additional_evidence_file;
 
+    /**
+     * @var string
+     */
     public $additional_evidence_text;
 
+    /**
+     * @var string
+     */
     public $proof_of_delivery_or_service_date_file;
 
+    /**
+     * @var string
+     */
     public $proof_of_delivery_or_service_date_text;
 }

--- a/lib/Checkout/Disputes/DisputesQueryFilter.php
+++ b/lib/Checkout/Disputes/DisputesQueryFilter.php
@@ -6,27 +6,60 @@ use Checkout\Common\QueryFilterDateRange;
 
 class DisputesQueryFilter extends QueryFilterDateRange
 {
+    /**
+     * @var int
+     */
     public $limit;
 
+    /**
+     * @var int
+     */
     public $skip;
 
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $statuses;
 
+    /**
+     * @var string
+     */
     public $payment_id;
 
+    /**
+     * @var string
+     */
     public $payment_reference;
 
+    /**
+     * @var string
+     */
     public $payment_arn;
 
+    /**
+     * @var string
+     */
     public $this_channel_only;
 
     //Fields only for CS2
 
+    /**
+     * @var string
+     */
     public $entity_ids;
 
+    /**
+     * @var string
+     */
     public $sub_entity_ids;
 
+    /**
+     * @var string
+     */
     public $payment_mcc;
 }

--- a/lib/Checkout/Environment.php
+++ b/lib/Checkout/Environment.php
@@ -11,6 +11,14 @@ final class Environment
     private $balancesUri;
     private $isSandbox;
 
+    /**
+     * @param string $baseUri
+     * @param string $authorizationUri
+     * @param string $filesBaseUrl
+     * @param string $transfersUri
+     * @param string $balancesUri
+     * @param bool $isSandbox
+     */
     private function __construct(
         $baseUri,
         $authorizationUri,
@@ -27,6 +35,9 @@ final class Environment
         $this->isSandbox = $isSandbox;
     }
 
+    /**
+     * @return Environment
+     */
     public static function sandbox()
     {
         return new Environment(
@@ -39,6 +50,9 @@ final class Environment
         );
     }
 
+    /**
+     * @return Environment
+     */
     public static function production()
     {
 
@@ -52,31 +66,49 @@ final class Environment
         );
     }
 
+    /**
+     * @return string
+     */
     public function getBaseUri()
     {
         return $this->baseUri;
     }
 
+    /**
+     * @return string
+     */
     public function getAuthorizationUri()
     {
         return $this->authorizationUri;
     }
 
+    /**
+     * @return string
+     */
     public function getFilesBaseUri()
     {
         return $this->filesBaseUri;
     }
 
+    /**
+     * @return string
+     */
     public function getTransfersUri()
     {
         return $this->transfersUri;
     }
 
+    /**
+     * @return bool
+     */
     public function isSandbox()
     {
         return $this->isSandbox;
     }
 
+    /**
+     * @return string
+     */
     public function getBalancesUri()
     {
         return $this->balancesUri;

--- a/lib/Checkout/Events/RetrieveEventsRequest.php
+++ b/lib/Checkout/Events/RetrieveEventsRequest.php
@@ -6,15 +6,33 @@ use Checkout\Common\QueryFilterDateRange;
 
 class RetrieveEventsRequest extends QueryFilterDateRange
 {
+    /**
+     * @var string
+     */
     public $payment_id;
 
+    /**
+     * @var string
+     */
     public $charge_id;
 
+    /**
+     * @var string
+     */
     public $track_id;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var int
+     */
     public $skip;
 
+    /**
+     * @var int
+     */
     public $limit;
 }

--- a/lib/Checkout/Files/FileRequest.php
+++ b/lib/Checkout/Files/FileRequest.php
@@ -4,8 +4,13 @@ namespace Checkout\Files;
 
 class FileRequest
 {
+    /**
+     * @var string
+     */
     public $file;
 
+    /**
+     * @var string
+     */
     public $purpose;
-
 }

--- a/lib/Checkout/Forex/QuoteRequest.php
+++ b/lib/Checkout/Forex/QuoteRequest.php
@@ -2,15 +2,32 @@
 
 namespace Checkout\Forex;
 
+use Checkout\Common\Currency;
+
 class QuoteRequest
 {
+    /**
+     * @var Currency
+     */
     public $source_currency;
 
+    /**
+     * @var int
+     */
     public $source_amount;
 
+    /**
+     * @var Currency
+     */
     public $destination_currency;
 
+    /**
+     * @var int
+     */
     public $destination_amount;
 
+    /**
+     * @var string
+     */
     public $process_channel_id;
 }

--- a/lib/Checkout/Four/CheckoutApi.php
+++ b/lib/Checkout/Four/CheckoutApi.php
@@ -56,81 +56,133 @@ final class CheckoutApi extends CheckoutApmApi
         );
     }
 
+    /**
+     * @return TokensClient
+     */
     public function getTokensClient()
     {
         return $this->tokensClient;
     }
 
+    /**
+     * @return CustomersClient
+     */
     public function getCustomersClient()
     {
         return $this->customersClient;
     }
 
+    /**
+     * @return PaymentsClient
+     */
     public function getPaymentsClient()
     {
         return $this->paymentsClient;
     }
 
+    /**
+     * @return InstrumentsClient
+     */
     public function getInstrumentsClient()
     {
         return $this->instrumentsClient;
     }
 
+    /**
+     * @return ForexClient
+     */
     public function getForexClient()
     {
         return $this->forexClient;
     }
 
+    /**
+     * @return DisputesClient
+     */
     public function getDisputesClient()
     {
         return $this->disputesClient;
     }
 
+    /**
+     * @return SessionsClient
+     */
     public function getSessionsClient()
     {
         return $this->sessionsClient;
     }
 
+    /**
+     * @return MarketplaceClient
+     */
     public function getMarketplaceClient()
     {
         return $this->marketplaceClient;
     }
 
+    /**
+     * @return HostedPaymentsClient
+     */
     public function getHostedPaymentsClient()
     {
         return $this->hostedPaymentsClient;
     }
 
+    /**
+     * @return PaymentLinksClient
+     */
     public function getPaymentLinksClient()
     {
         return $this->paymentLinksClient;
     }
 
+    /**
+     * @return RiskClient
+     */
     public function getRiskClient()
     {
         return $this->riskClient;
     }
 
+    /**
+     * @return WorkflowsClient
+     */
     public function getWorkflowsClient()
     {
         return $this->workflowsClient;
     }
 
+    /**
+     * @param CheckoutConfiguration $configuration
+     * @return ApiClient
+     */
     private function getBaseApiClient(CheckoutConfiguration $configuration)
     {
         return new ApiClient($configuration, $configuration->getEnvironment()->getBaseUri());
     }
 
+    /**
+     * @param CheckoutConfiguration $configuration
+     * @return ApiClient
+     */
     private function getFilesApiClient(CheckoutConfiguration $configuration)
     {
         return new ApiClient($configuration, $configuration->getEnvironment()->getFilesBaseUri());
     }
 
+    /**
+     * @param CheckoutConfiguration $configuration
+     * @return ApiClient
+     */
     private function getTransfersApiClient(CheckoutConfiguration $configuration)
     {
         return new ApiClient($configuration, $configuration->getEnvironment()->getTransfersUri());
     }
 
+    /**
+     * @param CheckoutConfiguration $configuration
+     * @return ApiClient
+     */
     private function getBalancesApiClient(CheckoutConfiguration $configuration)
     {
         return new ApiClient($configuration, $configuration->getEnvironment()->getBalancesUri());

--- a/lib/Checkout/Four/CheckoutApmApi.php
+++ b/lib/Checkout/Four/CheckoutApmApi.php
@@ -15,9 +15,11 @@ class CheckoutApmApi
         $this->idealClient = new IdealClient($apiClient, $configuration);
     }
 
+    /**
+     * @return IdealClient
+     */
     public function getIdealClient()
     {
         return $this->idealClient;
     }
-
 }

--- a/lib/Checkout/Four/FourOAuthCheckoutSdkBuilder.php
+++ b/lib/Checkout/Four/FourOAuthCheckoutSdkBuilder.php
@@ -17,6 +17,11 @@ class FourOAuthCheckoutSdkBuilder extends AbstractCheckoutSdkBuilder
     protected $authorizationUri = null;
     protected $scopes = array();
 
+    /**
+     * @param string $clientId
+     * @param string $clientSecret
+     * @return $this
+     */
     public function clientCredentials(
         $clientId,
         $clientSecret
@@ -26,12 +31,20 @@ class FourOAuthCheckoutSdkBuilder extends AbstractCheckoutSdkBuilder
         return $this;
     }
 
+    /**
+     * @param string $authorizationUri
+     * @return $this
+     */
     public function authorizationUri($authorizationUri)
     {
         $this->authorizationUri = $authorizationUri;
         return $this;
     }
 
+    /**
+     * @param array $scopes
+     * @return $this
+     */
     public function scopes(array $scopes)
     {
         $this->scopes = $scopes;

--- a/lib/Checkout/Four/FourStaticKeysCheckoutSdkBuilder.php
+++ b/lib/Checkout/Four/FourStaticKeysCheckoutSdkBuilder.php
@@ -12,11 +12,17 @@ class FourStaticKeysCheckoutSdkBuilder extends AbstractStaticKeysCheckoutSdkBuil
     const PUBLIC_KEY_PATTERN = "/^pk_(sbox_)?[a-z2-7]{26}[a-z2-7*#$=]$/";
     const SECRET_KEY_PATTERN = "/^sk_(sbox_)?[a-z2-7]{26}[a-z2-7*#$=]$/";
 
+    /**
+     * @param string $publicKey
+     */
     public function setPublicKey($publicKey)
     {
         $this->publicKey = $publicKey;
     }
 
+    /**
+     * @param string $secretKey
+     */
     public function setSecretKey($secretKey)
     {
         $this->secretKey = $secretKey;

--- a/lib/Checkout/Four/OAuthAccessToken.php
+++ b/lib/Checkout/Four/OAuthAccessToken.php
@@ -10,12 +10,19 @@ class OAuthAccessToken
     private $token;
     private $expirationDate;
 
+    /**
+     * @param string $token
+     * @param DateTime $expirationDate
+     */
     public function __construct($token, DateTime $expirationDate)
     {
         $this->token = $token;
         $this->expirationDate = $expirationDate;
     }
 
+    /**
+     * @return bool
+     */
     public function isValid()
     {
         if (is_null($this->expirationDate)) {
@@ -24,14 +31,19 @@ class OAuthAccessToken
         return $this->expirationDate > new DateTime();
     }
 
+    /**
+     * @return string
+     */
     public function getToken()
     {
         return $this->token;
     }
 
+    /**
+     * @return DateTime
+     */
     public function getExpirationDate()
     {
         return $this->expirationDate;
     }
-
 }

--- a/lib/Checkout/Instruments/CreateInstrumentRequest.php
+++ b/lib/Checkout/Instruments/CreateInstrumentRequest.php
@@ -2,17 +2,28 @@
 
 namespace Checkout\Instruments;
 
+use Checkout\Common\InstrumentType;
+
 class CreateInstrumentRequest
 {
 
+    /**
+     * @var InstrumentType
+     */
     public $type;
 
+    /**
+     * @var string
+     */
     public $token;
 
-    // InstrumentAccountHolder
+    /**
+     * @var InstrumentAccountHolder
+     */
     public $account_holder;
 
-    // InstrumentCustomerRequest
+    /**
+     * @var InstrumentCustomerRequest
+     */
     public $customer;
-
 }

--- a/lib/Checkout/Instruments/Four/Create/CreateBankAccountInstrumentRequest.php
+++ b/lib/Checkout/Instruments/Four/Create/CreateBankAccountInstrumentRequest.php
@@ -2,6 +2,11 @@
 
 namespace Checkout\Instruments\Four\Create;
 
+use Checkout\Common\Country;
+use Checkout\Common\Currency;
+use Checkout\Common\Four\AccountHolder;
+use Checkout\Common\Four\AccountType;
+use Checkout\Common\Four\BankDetails;
 use Checkout\Common\InstrumentType;
 
 class CreateBankAccountInstrumentRequest extends CreateInstrumentRequest
@@ -11,36 +16,68 @@ class CreateBankAccountInstrumentRequest extends CreateInstrumentRequest
         parent::__construct(InstrumentType::$bank_account);
     }
 
-    //AccountType
+    /**
+     * @var AccountType
+     */
     public $account_type;
 
+    /**
+     * @var string
+     */
     public $account_number;
 
+    /**
+     * @var string
+     */
     public $bank_code;
 
+    /**
+     * @var string
+     */
     public $branch_code;
 
+    /**
+     * @var string
+     */
     public $iban;
 
+    /**
+     * @var string
+     */
     public $bban;
 
+    /**
+     * @var string
+     */
     public $swift_bic;
 
-    //Currency
+    /**
+     * @var Currency
+     */
     public $currency;
 
-    //CountryCode
+    /**
+     * @var Country
+     */
     public $country;
 
+    /**
+     * @var string
+     */
     public $processing_channel_id;
 
-    // AccountHolder
+    /**
+     * @var AccountHolder
+     */
     public $account_holder;
 
-    // BankDetails
+    /**
+     * @var BankDetails
+     */
     public $bank_details;
 
-    // CreateCustomerInstrumentRequest
+    /**
+     * @var CreateCustomerInstrumentRequest
+     */
     public $customer;
-
 }

--- a/lib/Checkout/Instruments/Four/Create/CreateCustomerInstrumentRequest.php
+++ b/lib/Checkout/Instruments/Four/Create/CreateCustomerInstrumentRequest.php
@@ -2,16 +2,32 @@
 
 namespace Checkout\Instruments\Four\Create;
 
+use Checkout\Common\Phone;
+
 class CreateCustomerInstrumentRequest
 {
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $email;
 
+    /**
+     * @var string
+     */
     public $name;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
 
+    /**
+     * @var bool
+     */
     public $default;
 }

--- a/lib/Checkout/Instruments/Four/Create/CreateInstrumentRequest.php
+++ b/lib/Checkout/Instruments/Four/Create/CreateInstrumentRequest.php
@@ -2,15 +2,17 @@
 
 namespace Checkout\Instruments\Four\Create;
 
+use Checkout\Common\InstrumentType;
+
 abstract class CreateInstrumentRequest
 {
-    //InstrumentType
+    /**
+     * @var InstrumentType
+     */
     public $type;
 
     protected function __construct($type)
     {
         $this->type = $type;
     }
-
-
 }

--- a/lib/Checkout/Instruments/Four/Create/CreateTokenInstrumentRequest.php
+++ b/lib/Checkout/Instruments/Four/Create/CreateTokenInstrumentRequest.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Instruments\Four\Create;
 
+use Checkout\Common\Four\AccountHolder;
 use Checkout\Common\InstrumentType;
 
 class CreateTokenInstrumentRequest extends CreateInstrumentRequest
@@ -12,12 +13,18 @@ class CreateTokenInstrumentRequest extends CreateInstrumentRequest
         parent::__construct(InstrumentType::$token);
     }
 
+    /**
+     * @var string
+     */
     public $token;
 
-    // AccountHolder
+    /**
+     * @var AccountHolder
+     */
     public $account_holder;
 
-    // CreateCustomerInstrumentRequest
+    /**
+     * @var CreateCustomerInstrumentRequest
+     */
     public $customer;
-
 }

--- a/lib/Checkout/Instruments/Four/Update/UpdateBankInstrumentRequest.php
+++ b/lib/Checkout/Instruments/Four/Update/UpdateBankInstrumentRequest.php
@@ -2,6 +2,11 @@
 
 namespace Checkout\Instruments\Four\Update;
 
+use Checkout\Common\Country;
+use Checkout\Common\Currency;
+use Checkout\Common\Four\AccountHolder;
+use Checkout\Common\Four\AccountType;
+use Checkout\Common\Four\BankDetails;
 use Checkout\Common\InstrumentType;
 
 class UpdateBankInstrumentRequest extends UpdateInstrumentRequest
@@ -11,35 +16,68 @@ class UpdateBankInstrumentRequest extends UpdateInstrumentRequest
         parent::__construct(InstrumentType::$bank_account);
     }
 
-    //AccountType
+    /**
+     * @var AccountType
+     */
     public $account_type;
 
+    /**
+     * @var string
+     */
     public $account_number;
 
+    /**
+     * @var string
+     */
     public $bank_code;
 
+    /**
+     * @var string
+     */
     public $branch_code;
 
+    /**
+     * @var string
+     */
     public $iban;
 
+    /**
+     * @var string
+     */
     public $bban;
 
+    /**
+     * @var string
+     */
     public $swift_bic;
 
-    //Currency
+    /**
+     * @var Currency
+     */
     public $currency;
 
-    //CountryCode
+    /**
+     * @var Country
+     */
     public $country;
 
+    /**
+     * @var string
+     */
     public $processing_channel_id;
 
-    // AccountHolder
+    /**
+     * @var AccountHolder
+     */
     public $account_holder;
 
-    // BankDetails
+    /**
+     * @var BankDetails
+     */
     public $bank_details;
 
-    // UpdateCustomerRequest
+    /**
+     * @var UpdateCustomerRequest
+     */
     public $customer;
 }

--- a/lib/Checkout/Instruments/Four/Update/UpdateCardInstrumentRequest.php
+++ b/lib/Checkout/Instruments/Four/Update/UpdateCardInstrumentRequest.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Instruments\Four\Update;
 
+use Checkout\Common\Four\AccountHolder;
 use Checkout\Common\InstrumentType;
 
 class UpdateCardInstrumentRequest extends UpdateInstrumentRequest
@@ -11,15 +12,28 @@ class UpdateCardInstrumentRequest extends UpdateInstrumentRequest
         parent::__construct(InstrumentType::$card);
     }
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $name;
 
-    // UpdateCustomerRequest
+    /**
+     * @var UpdateCustomerRequest
+     */
     public $customer;
 
-    // AccountHolder
+    /**
+     * @var AccountHolder
+     */
     public $account_holder;
 }

--- a/lib/Checkout/Instruments/Four/Update/UpdateCustomerRequest.php
+++ b/lib/Checkout/Instruments/Four/Update/UpdateCustomerRequest.php
@@ -4,7 +4,13 @@ namespace Checkout\Instruments\Four\Update;
 
 class UpdateCustomerRequest
 {
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var bool
+     */
     public $default;
 }

--- a/lib/Checkout/Instruments/Four/Update/UpdateInstrumentRequest.php
+++ b/lib/Checkout/Instruments/Four/Update/UpdateInstrumentRequest.php
@@ -2,14 +2,17 @@
 
 namespace Checkout\Instruments\Four\Update;
 
+use Checkout\Common\InstrumentType;
+
 abstract class UpdateInstrumentRequest
 {
-    //InstrumentType
+    /**
+     * @var InstrumentType
+     */
     public $type;
 
     protected function __construct($type)
     {
         $this->type = $type;
     }
-
 }

--- a/lib/Checkout/Instruments/Four/Update/UpdateTokenInstrumentRequest.php
+++ b/lib/Checkout/Instruments/Four/Update/UpdateTokenInstrumentRequest.php
@@ -11,6 +11,8 @@ class UpdateTokenInstrumentRequest extends UpdateInstrumentRequest
         parent::__construct(InstrumentType::$token);
     }
 
+    /**
+     * @var string
+     */
     public $token;
-
 }

--- a/lib/Checkout/Instruments/InstrumentAccountHolder.php
+++ b/lib/Checkout/Instruments/InstrumentAccountHolder.php
@@ -2,11 +2,18 @@
 
 namespace Checkout\Instruments;
 
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
+
 class InstrumentAccountHolder
 {
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
 }

--- a/lib/Checkout/Instruments/InstrumentCustomerRequest.php
+++ b/lib/Checkout/Instruments/InstrumentCustomerRequest.php
@@ -6,6 +6,8 @@ use Checkout\Common\CustomerRequest;
 
 class InstrumentCustomerRequest extends CustomerRequest
 {
-
+    /**
+     * @var bool
+     */
     public $default;
 }

--- a/lib/Checkout/Instruments/UpdateInstrumentCustomerRequest.php
+++ b/lib/Checkout/Instruments/UpdateInstrumentCustomerRequest.php
@@ -4,9 +4,13 @@ namespace Checkout\Instruments;
 
 class UpdateInstrumentCustomerRequest
 {
-
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var bool
+     */
     public $default;
-
 }

--- a/lib/Checkout/Instruments/UpdateInstrumentRequest.php
+++ b/lib/Checkout/Instruments/UpdateInstrumentRequest.php
@@ -4,15 +4,28 @@ namespace Checkout\Instruments;
 
 class UpdateInstrumentRequest
 {
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $name;
 
-    // InstrumentAccountHolder
+    /**
+     * @var InstrumentAccountHolder
+     */
     public $account_holder;
 
-    // UpdateInstrumentCustomerRequest
+    /**
+     * @var UpdateInstrumentCustomerRequest
+     */
     public $customer;
 }

--- a/lib/Checkout/Marketplace/Balances/BalancesQuery.php
+++ b/lib/Checkout/Marketplace/Balances/BalancesQuery.php
@@ -6,5 +6,8 @@ use Checkout\Common\AbstractQueryFilter;
 
 class BalancesQuery extends AbstractQueryFilter
 {
+    /**
+     * @var string
+     */
     public $query;
 }

--- a/lib/Checkout/Marketplace/Company.php
+++ b/lib/Checkout/Marketplace/Company.php
@@ -2,23 +2,42 @@
 
 namespace Checkout\Marketplace;
 
+use Checkout\Common\Address;
+
 class Company
 {
+    /**
+     * @var string
+     */
     public $business_registration_number;
 
+    /**
+     * @var string
+     */
     public $legal_name;
 
+    /**
+     * @var string
+     */
     public $trading_name;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $principal_address;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $registered_address;
 
-    // EntityDocument
+    /**
+     * @var EntityDocument
+     */
     public $document;
 
-    // array Representative
+    /**
+     * @var array of Representative
+     */
     public $representatives;
 }

--- a/lib/Checkout/Marketplace/ContactDetails.php
+++ b/lib/Checkout/Marketplace/ContactDetails.php
@@ -2,8 +2,12 @@
 
 namespace Checkout\Marketplace;
 
+use Checkout\Common\Phone;
+
 class ContactDetails
 {
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
 }

--- a/lib/Checkout/Marketplace/DateOfBirth.php
+++ b/lib/Checkout/Marketplace/DateOfBirth.php
@@ -4,9 +4,18 @@ namespace Checkout\Marketplace;
 
 class DateOfBirth
 {
+    /**
+     * @var int
+     */
     public $day;
 
+    /**
+     * @var int
+     */
     public $month;
 
+    /**
+     * @var int
+     */
     public $year;
 }

--- a/lib/Checkout/Marketplace/Document.php
+++ b/lib/Checkout/Marketplace/Document.php
@@ -4,10 +4,18 @@ namespace Checkout\Marketplace;
 
 class Document
 {
-    // DocumentType
+    /**
+     * @var DocumentType
+     */
     public $type;
 
+    /**
+     * @var string
+     */
     public $front;
 
+    /**
+     * @var string
+     */
     public $back;
 }

--- a/lib/Checkout/Marketplace/EntityDocument.php
+++ b/lib/Checkout/Marketplace/EntityDocument.php
@@ -4,7 +4,13 @@ namespace Checkout\Marketplace;
 
 class EntityDocument
 {
+    /**
+     * @var string
+     */
     public $file_id;
 
+    /**
+     * @var string
+     */
     public $type;
 }

--- a/lib/Checkout/Marketplace/Identification.php
+++ b/lib/Checkout/Marketplace/Identification.php
@@ -4,8 +4,13 @@ namespace Checkout\Marketplace;
 
 class Identification
 {
+    /**
+     * @var string
+     */
     public $national_id_number;
 
-    // Document
+    /**
+     * @var Document
+     */
     public $document;
 }

--- a/lib/Checkout/Marketplace/Individual.php
+++ b/lib/Checkout/Marketplace/Individual.php
@@ -2,24 +2,47 @@
 
 namespace Checkout\Marketplace;
 
+use Checkout\Common\Address;
+
 class Individual
 {
+    /**
+     * @var string
+     */
     public $first_name;
 
+    /**
+     * @var string
+     */
     public $middle_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
 
+    /**
+     * @var string
+     */
     public $trading_name;
 
+    /**
+     * @var string
+     */
     public $national_tax_id;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $registered_address;
 
-    // DateOfBirth
+    /**
+     * @var DateOfBirth
+     */
     public $date_of_birth;
 
-    // Identification
+    /**
+     * @var Identification
+     */
     public $identification;
 }

--- a/lib/Checkout/Marketplace/InstrumentDocument.php
+++ b/lib/Checkout/Marketplace/InstrumentDocument.php
@@ -4,7 +4,13 @@ namespace Checkout\Marketplace;
 
 class InstrumentDocument
 {
+    /**
+     * @var string
+     */
     public $type;
 
+    /**
+     * @var string
+     */
     public $file_id;
 }

--- a/lib/Checkout/Marketplace/MarketplaceAccountHolder.php
+++ b/lib/Checkout/Marketplace/MarketplaceAccountHolder.php
@@ -2,25 +2,48 @@
 
 namespace Checkout\Marketplace;
 
+use Checkout\Common\Country;
 use Checkout\Common\Four\AccountHolder;
 
 class MarketplaceAccountHolder extends AccountHolder
 {
+    /**
+     * @var MarketplaceAccountHolderType
+     */
     public $type;
 
+    /**
+     * @var string
+     */
     public $company_name;
 
+    /**
+     * @var string
+     */
     public $tax_id;
 
-    // DateOfBirth
+    /**
+     * @var DateOfBirth
+     */
     public $date_of_birth;
 
+    /**
+     * @var Country
+     */
     public $country_of_birth;
 
+    /**
+     * @var string
+     */
     public $residential_status;
 
-    // Identification
+    /**
+     * @var Identification
+     */
     public $identification;
 
+    /**
+     * @var string
+     */
     public $email;
 }

--- a/lib/Checkout/Marketplace/MarketplaceFileRequest.php
+++ b/lib/Checkout/Marketplace/MarketplaceFileRequest.php
@@ -6,5 +6,8 @@ use Checkout\Files\FileRequest;
 
 class MarketplaceFileRequest extends FileRequest
 {
+    /**
+     * @var string
+     */
     public $content_type;
 }

--- a/lib/Checkout/Marketplace/MarketplacePaymentInstrument.php
+++ b/lib/Checkout/Marketplace/MarketplacePaymentInstrument.php
@@ -2,6 +2,9 @@
 
 namespace Checkout\Marketplace;
 
+use Checkout\Common\Country;
+use Checkout\Common\Currency;
+use Checkout\Common\Four\BankDetails;
 use Checkout\Common\InstrumentType;
 
 class MarketplacePaymentInstrument
@@ -11,34 +14,73 @@ class MarketplacePaymentInstrument
         $this->type = InstrumentType::$bank_account;
     }
 
+    /**
+     * @var InstrumentType
+     */
     public $type;
 
+    /**
+     * @var string
+     */
     public $label;
 
+    /**
+     * @var string
+     */
     public $account_type;
 
+    /**
+     * @var string
+     */
     public $account_number;
 
+    /**
+     * @var string
+     */
     public $bank_code;
 
+    /**
+     * @var string
+     */
     public $branch_code;
 
+    /**
+     * @var string
+     */
     public $iban;
 
+    /**
+     * @var string
+     */
     public $bban;
 
+    /**
+     * @var string
+     */
     public $swift_bic;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
+    /**
+     * @var Country
+     */
     public $country;
 
-    // InstrumentDocument
+    /**
+     * @var InstrumentDocument
+     */
     public $document;
 
-    // BankDetails
+    /**
+     * @var BankDetails
+     */
     public $bank;
 
-    // MarketplaceAccountHolder
+    /**
+     * @var MarketplaceAccountHolder
+     */
     public $account_holder;
 }

--- a/lib/Checkout/Marketplace/OnboardEntityRequest.php
+++ b/lib/Checkout/Marketplace/OnboardEntityRequest.php
@@ -4,17 +4,28 @@ namespace Checkout\Marketplace;
 
 class OnboardEntityRequest
 {
+    /**
+     * @var string
+     */
     public $reference;
 
-    // ContactDetails
+    /**
+     * @var ContactDetails
+     */
     public $contact_details;
 
-    // Profile
+    /**
+     * @var Profile
+     */
     public $profile;
 
-    // Company
+    /**
+     * @var Company
+     */
     public $company;
 
-    // Individual
+    /**
+     * @var Individual
+     */
     public $individual;
 }

--- a/lib/Checkout/Marketplace/Profile.php
+++ b/lib/Checkout/Marketplace/Profile.php
@@ -2,11 +2,22 @@
 
 namespace Checkout\Marketplace;
 
+use Checkout\Common\Currency;
+
 class Profile
 {
+    /**
+     * @var array
+     */
     public $urls;
 
+    /**
+     * @var array
+     */
     public $mccs;
 
+    /**
+     * @var Currency
+     */
     public $default_holding_currency;
 }

--- a/lib/Checkout/Marketplace/Representative.php
+++ b/lib/Checkout/Marketplace/Representative.php
@@ -2,21 +2,38 @@
 
 namespace Checkout\Marketplace;
 
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
+
 class Representative
 {
+    /**
+     * @var string
+     */
     public $first_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $address;
 
-    // Identification
+    /**
+     * @var Identification
+     */
     public $identification;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
 
-    // DateOfBirth
+    /**
+     * @var DateOfBirth
+     */
     public $date_of_birth;
 }

--- a/lib/Checkout/Marketplace/Transfer/CreateTransferRequest.php
+++ b/lib/Checkout/Marketplace/Transfer/CreateTransferRequest.php
@@ -4,15 +4,23 @@ namespace Checkout\Marketplace\Transfer;
 
 class CreateTransferRequest
 {
+    /**
+     * @var string
+     */
     public $reference;
 
-    // TransferType
+    /**
+     * @var TransferType
+     */
     public $transfer_type;
 
-    // TransferSource
+    /**
+     * @var TransferSource
+     */
     public $source;
 
-    // TransferDestination
+    /**
+     * @var TransferDestination
+     */
     public $destination;
-
 }

--- a/lib/Checkout/Marketplace/Transfer/TransferDestination.php
+++ b/lib/Checkout/Marketplace/Transfer/TransferDestination.php
@@ -4,5 +4,8 @@ namespace Checkout\Marketplace\Transfer;
 
 class TransferDestination
 {
+    /**
+     * @var string
+     */
     public $id;
 }

--- a/lib/Checkout/Marketplace/Transfer/TransferSource.php
+++ b/lib/Checkout/Marketplace/Transfer/TransferSource.php
@@ -4,7 +4,13 @@ namespace Checkout\Marketplace\Transfer;
 
 class TransferSource
 {
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var int
+     */
     public $amount;
 }

--- a/lib/Checkout/Payments/BillingDescriptor.php
+++ b/lib/Checkout/Payments/BillingDescriptor.php
@@ -4,12 +4,20 @@ namespace Checkout\Payments;
 
 class BillingDescriptor
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $city;
 
     //Only available in four
 
+    /**
+     * @var string
+     */
     public $reference;
-
 }

--- a/lib/Checkout/Payments/BillingInformation.php
+++ b/lib/Checkout/Payments/BillingInformation.php
@@ -2,12 +2,18 @@
 
 namespace Checkout\Payments;
 
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
+
 class BillingInformation
 {
-    // Address
+    /**
+     * @var Address
+     */
     public $address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/CaptureRequest.php
+++ b/lib/Checkout/Payments/CaptureRequest.php
@@ -4,10 +4,18 @@ namespace Checkout\Payments;
 
 class CaptureRequest
 {
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var array
+     */
     public $metadata;
-
 }

--- a/lib/Checkout/Payments/Destination/PaymentRequestCardDestination.php
+++ b/lib/Checkout/Payments/Destination/PaymentRequestCardDestination.php
@@ -2,6 +2,8 @@
 
 namespace Checkout\Payments\Destination;
 
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
 use Checkout\Payments\PaymentDestinationType;
 
 class PaymentRequestCardDestination extends PaymentRequestDestination
@@ -12,22 +14,43 @@ class PaymentRequestCardDestination extends PaymentRequestDestination
         parent::__construct(PaymentDestinationType::$card);
     }
 
+    /**
+     * @var string
+     */
     public $number;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $first_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
 
+    /**
+     * @var string
+     */
     public $name;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/Destination/PaymentRequestDestination.php
+++ b/lib/Checkout/Payments/Destination/PaymentRequestDestination.php
@@ -2,13 +2,17 @@
 
 namespace Checkout\Payments\Destination;
 
+use Checkout\Payments\PaymentDestinationType;
+
 abstract class PaymentRequestDestination
 {
+    /**
+     * @var PaymentDestinationType
+     */
     public $type;
 
     public function __construct($type)
     {
         $this->type = $type;
     }
-
 }

--- a/lib/Checkout/Payments/Destination/PaymentRequestIdDestination.php
+++ b/lib/Checkout/Payments/Destination/PaymentRequestIdDestination.php
@@ -11,10 +11,18 @@ class PaymentRequestIdDestination extends PaymentRequestDestination
         parent::__construct(PaymentDestinationType::$id);
     }
 
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $first_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
-
 }

--- a/lib/Checkout/Payments/Destination/PaymentRequestTokenDestination.php
+++ b/lib/Checkout/Payments/Destination/PaymentRequestTokenDestination.php
@@ -2,6 +2,8 @@
 
 namespace Checkout\Payments\Destination;
 
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
 use Checkout\Payments\PaymentDestinationType;
 
 class PaymentRequestTokenDestination extends PaymentRequestDestination
@@ -11,16 +13,28 @@ class PaymentRequestTokenDestination extends PaymentRequestDestination
         parent::__construct(PaymentDestinationType::$token);
     }
 
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $first_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/Four/AuthorizationRequest.php
+++ b/lib/Checkout/Payments/Four/AuthorizationRequest.php
@@ -4,10 +4,18 @@ namespace Checkout\Payments\Four;
 
 class AuthorizationRequest
 {
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var string
+     */
     public $reference;
 
-    // array
+    /**
+     * @var array
+     */
     public $metadata;
 }

--- a/lib/Checkout/Payments/Four/CaptureRequest.php
+++ b/lib/Checkout/Payments/Four/CaptureRequest.php
@@ -4,14 +4,23 @@ namespace Checkout\Payments\Four;
 
 class CaptureRequest
 {
+    /**
+     * @var int
+     */
     public $amount;
 
-    //CaptureType
+    /**
+     * @var CaptureType
+     */
     public $capture_type;
 
+    /**
+     * @var string
+     */
     public $reference;
 
-    // array
+    /**
+     * @var array
+     */
     public $metadata;
-
 }

--- a/lib/Checkout/Payments/Four/Destination/PaymentBankAccountDestination.php
+++ b/lib/Checkout/Payments/Four/Destination/PaymentBankAccountDestination.php
@@ -2,6 +2,10 @@
 
 namespace Checkout\Payments\Four\Destination;
 
+use Checkout\Common\Country;
+use Checkout\Common\Four\AccountHolder;
+use Checkout\Common\Four\AccountType;
+use Checkout\Common\Four\BankDetails;
 use Checkout\Payments\PaymentDestinationType;
 
 class PaymentBankAccountDestination extends PaymentRequestDestination
@@ -12,25 +16,48 @@ class PaymentBankAccountDestination extends PaymentRequestDestination
         parent::__construct(PaymentDestinationType::$bank_account);
     }
 
-    //AccountType
+    /**
+     * @var AccountType
+     */
     public $account_type;
 
+    /**
+     * @var string
+     */
     public $account_number;
 
+    /**
+     * @var string
+     */
     public $bank_code;
 
+    /**
+     * @var string
+     */
     public $branch_code;
 
+    /**
+     * @var string
+     */
     public $iban;
 
+    /**
+     * @var string
+     */
     public $swift_bic;
 
+    /**
+     * @var Country
+     */
     public $country;
 
-    // AccountHolder
+    /**
+     * @var AccountHolder
+     */
     public $account_holder;
 
-    // BankDetails
+    /**
+     * @var BankDetails
+     */
     public $bank;
-
 }

--- a/lib/Checkout/Payments/Four/Destination/PaymentRequestDestination.php
+++ b/lib/Checkout/Payments/Four/Destination/PaymentRequestDestination.php
@@ -2,13 +2,17 @@
 
 namespace Checkout\Payments\Four\Destination;
 
+use Checkout\Payments\PaymentDestinationType;
+
 class PaymentRequestDestination
 {
+    /**
+     * @var PaymentDestinationType
+     */
     public $type;
 
     public function __construct($type)
     {
         $this->type = $type;
     }
-
 }

--- a/lib/Checkout/Payments/Four/Destination/PaymentRequestIdDestination.php
+++ b/lib/Checkout/Payments/Four/Destination/PaymentRequestIdDestination.php
@@ -11,6 +11,8 @@ class PaymentRequestIdDestination extends PaymentRequestDestination
         parent::__construct(PaymentDestinationType::$id);
     }
 
+    /**
+     * @var string
+     */
     public $id;
-
 }

--- a/lib/Checkout/Payments/Four/Request/PaymentInstruction.php
+++ b/lib/Checkout/Payments/Four/Request/PaymentInstruction.php
@@ -4,15 +4,28 @@ namespace Checkout\Payments\Four\Request;
 
 class PaymentInstruction
 {
+    /**
+     * @var string
+     */
     public $purpose;
 
+    /**
+     * @var string
+     */
     public $charge_bearer;
 
+    /**
+     * @var bool
+     */
     public $repair;
 
-    //InstructionScheme
+    /**
+     * @var InstructionScheme
+     */
     public $scheme;
 
+    /**
+     * @var string
+     */
     public $quote_id;
-
 }

--- a/lib/Checkout/Payments/Four/Request/PaymentRequest.php
+++ b/lib/Checkout/Payments/Four/Request/PaymentRequest.php
@@ -2,71 +2,149 @@
 
 namespace Checkout\Payments\Four\Request;
 
+use Checkout\Common\Currency;
+use Checkout\Common\CustomerRequest;
+use Checkout\Common\MarketplaceData;
+use Checkout\Payments\BillingDescriptor;
+use Checkout\Payments\Four\AuthorizationType;
+use Checkout\Payments\Four\Request\Source\AbstractRequestSource;
+use Checkout\Payments\Four\Sender\PaymentSender;
+use Checkout\Payments\PaymentRecipient;
+use Checkout\Payments\ProcessingSettings;
+use Checkout\Payments\RiskRequest;
+use Checkout\Payments\ShippingDetails;
+use Checkout\Payments\ThreeDsRequest;
+use DateTime;
+
 class PaymentRequest
 {
-    // AbstractRequestSource
+    /**
+     * @var AbstractRequestSource
+     */
     public $source;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
-    //AuthorizationType
+    /**
+     * @var AuthorizationType
+     */
     public $payment_type;
 
+    /**
+     * @var bool
+     */
     public $merchant_initiated;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var string
+     */
     public $description;
 
+    /**
+     * @var AuthorizationType
+     */
     public $authorization_type;
 
+    /**
+     * @var bool
+     */
     public $capture;
 
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $capture_on;
 
-    // CustomerRequest
+    /**
+     * @var CustomerRequest
+     */
     public $customer;
 
-    // BillingDescriptor
+    /**
+     * @var BillingDescriptor
+     */
     public $billing_descriptor;
 
-    // ShippingDetails
+    /**
+     * @var ShippingDetails
+     */
     public $shipping;
 
-    // ThreeDsRequest
+    /**
+     * @var ThreeDsRequest
+     */
     public $three_ds;
 
+    /**
+     * @var string
+     */
     public $processing_channel_id;
 
+    /**
+     * @var string
+     */
     public $previous_payment_id;
 
-    // RiskRequest
+    /**
+     * @var RiskRequest
+     */
     public $risk;
 
+    /**
+     * @var string
+     */
     public $success_url;
 
+    /**
+     * @var string
+     */
     public $failure_url;
 
+    /**
+     * @var string
+     */
     public $payment_ip;
 
-    // PaymentSender
+    /**
+     * @var PaymentSender
+     */
     public $sender;
 
-    // PaymentRecipient
+    /**
+     * @var PaymentRecipient
+     */
     public $recipient;
 
-    // MarketplaceData
+    /**
+     * @var MarketplaceData
+     */
     public $marketplace;
 
-    // ProcessingSettings
+    /**
+     * @var ProcessingSettings
+     */
     public $processing;
 
+    /**
+     * @var array
+     */
     public $metadata;
 
-    // array Four/Product
+    /**
+     * @var array of Four/Product
+     */
     public $items;
-
 }

--- a/lib/Checkout/Payments/Four/Request/PayoutBillingDescriptor.php
+++ b/lib/Checkout/Payments/Four/Request/PayoutBillingDescriptor.php
@@ -4,5 +4,8 @@ namespace Checkout\Payments\Four\Request;
 
 class PayoutBillingDescriptor
 {
+    /**
+     * @var string
+     */
     public $reference;
 }

--- a/lib/Checkout/Payments/Four/Request/PayoutRequest.php
+++ b/lib/Checkout/Payments/Four/Request/PayoutRequest.php
@@ -2,30 +2,56 @@
 
 namespace Checkout\Payments\Four\Request;
 
+use Checkout\Common\Currency;
+use Checkout\Payments\Four\Destination\PaymentRequestDestination;
+use Checkout\Payments\Four\Request\Source\PayoutRequestSource;
+use Checkout\Payments\Four\Sender\PaymentSender;
+
 class PayoutRequest
 {
 
-    // PayoutRequestSource
+    /**
+     * @var PayoutRequestSource
+     */
     public $source;
 
-    // PaymentRequestDestination
+    /**
+     * @var PaymentRequestDestination
+     */
     public $destination;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
+    /**
+     * @var string
+     */
     public $reference;
 
-    // PayoutBillingDescriptor
+    /**
+     * @var PayoutBillingDescriptor
+     */
     public $billing_descriptor;
 
-    // PaymentSender
+    /**
+     * @var PaymentSender
+     */
     public $sender;
 
-    // PaymentInstruction
+    /**
+     * @var PaymentInstruction
+     */
     public $instruction;
 
+    /**
+     * @var string
+     */
     public $processing_channel_id;
-
 }

--- a/lib/Checkout/Payments/Four/Request/Source/AbstractRequestSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/AbstractRequestSource.php
@@ -2,13 +2,17 @@
 
 namespace Checkout\Payments\Four\Request\Source;
 
+use Checkout\Common\PaymentSourceType;
+
 class AbstractRequestSource
 {
+    /**
+     * @var PaymentSourceType
+     */
     public $type;
 
     public function __construct($type)
     {
         $this->type = $type;
     }
-
 }

--- a/lib/Checkout/Payments/Four/Request/Source/Apm/RequestIdealSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/Apm/RequestIdealSource.php
@@ -12,7 +12,18 @@ class RequestIdealSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$ideal);
     }
 
+    /**
+     * @var string
+     */
     public $bic;
+
+    /**
+     * @var string
+     */
     public $description;
+
+    /**
+     * @var string
+     */
     public $language;
 }

--- a/lib/Checkout/Payments/Four/Request/Source/Apm/RequestTamaraSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/Apm/RequestTamaraSource.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Payments\Four\Request\Source\Apm;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Four\Request\Source\AbstractRequestSource;
 
@@ -12,5 +13,8 @@ class RequestTamaraSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$tamara);
     }
 
+    /**
+     * @var Address
+     */
     public $billing_address;
 }

--- a/lib/Checkout/Payments/Four/Request/Source/PayoutRequestCurrencyAccountSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/PayoutRequestCurrencyAccountSource.php
@@ -9,6 +9,8 @@ class PayoutRequestCurrencyAccountSource extends PayoutRequestSource
         parent::__construct(PayoutSourceType::$currencyAccount);
     }
 
+    /**
+     * @var string
+     */
     public $id;
-
 }

--- a/lib/Checkout/Payments/Four/Request/Source/PayoutRequestSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/PayoutRequestSource.php
@@ -4,13 +4,18 @@ namespace Checkout\Payments\Four\Request\Source;
 
 class PayoutRequestSource
 {
+    /**
+     * @var PayoutSourceType
+     */
     public $type;
 
+    /**
+     * @var int
+     */
     public $amount;
 
     public function __construct($type)
     {
         $this->type = $type;
     }
-
 }

--- a/lib/Checkout/Payments/Four/Request/Source/RequestCardSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/RequestCardSource.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Payments\Four\Request\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class RequestCardSource extends AbstractRequestSource
 {
@@ -12,22 +14,43 @@ class RequestCardSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$card);
     }
 
+    /**
+     * @var string
+     */
     public $number;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $cvv;
 
+    /**
+     * @var bool
+     */
     public $stored;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/Four/Request/Source/RequestIdSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/RequestIdSource.php
@@ -12,8 +12,13 @@ class RequestIdSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$id);
     }
 
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $cvv;
-
 }

--- a/lib/Checkout/Payments/Four/Request/Source/RequestNetworkTokenSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/RequestNetworkTokenSource.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Payments\Four\Request\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class RequestNetworkTokenSource extends AbstractRequestSource
 {
@@ -12,28 +14,58 @@ class RequestNetworkTokenSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$network_token);
     }
 
+    /**
+     * @var string
+     */
     public $token;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $token_type;
 
+    /**
+     * @var string
+     */
     public $cryptogram;
 
+    /**
+     * @var string
+     */
     public $eci;
 
+    /**
+     * @var bool
+     */
     public $stored;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $cvv;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/Four/Request/Source/RequestProviderTokenSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/RequestProviderTokenSource.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Payments\Four\Request\Source;
 
+use Checkout\Common\Four\AccountHolder;
 use Checkout\Common\PaymentSourceType;
 
 class RequestProviderTokenSource extends AbstractRequestSource
@@ -12,10 +13,18 @@ class RequestProviderTokenSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$provider_token);
     }
 
+    /**
+     * @var string
+     */
     public $payment_method;
 
+    /**
+     * @var string
+     */
     public $token;
 
-    // AccountHolder
+    /**
+     * @var AccountHolder
+     */
     public $account_holder;
 }

--- a/lib/Checkout/Payments/Four/Request/Source/RequestTokenSource.php
+++ b/lib/Checkout/Payments/Four/Request/Source/RequestTokenSource.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Payments\Four\Request\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class RequestTokenSource extends AbstractRequestSource
 {
@@ -12,12 +14,18 @@ class RequestTokenSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$token);
     }
 
+    /**
+     * @var string
+     */
     public $token;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/Four/Sender/Identification.php
+++ b/lib/Checkout/Payments/Four/Sender/Identification.php
@@ -2,12 +2,22 @@
 
 namespace Checkout\Payments\Four\Sender;
 
+use Checkout\Common\Country;
+
 class Identification
 {
-    //IdentificationType
+    /**
+     * @var IdentificationType
+     */
     public $type;
 
+    /**
+     * @var string
+     */
     public $number;
 
+    /**
+     * @var Country
+     */
     public $issuing_country;
 }

--- a/lib/Checkout/Payments/Four/Sender/PaymentCorporateSender.php
+++ b/lib/Checkout/Payments/Four/Sender/PaymentCorporateSender.php
@@ -2,6 +2,8 @@
 
 namespace Checkout\Payments\Four\Sender;
 
+use Checkout\Common\Address;
+
 class PaymentCorporateSender extends PaymentSender
 {
     public function __construct()
@@ -9,9 +11,13 @@ class PaymentCorporateSender extends PaymentSender
         parent::__construct(PaymentSenderType::$corporate);
     }
 
+    /**
+     * @var string
+     */
     public $company_name;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $address;
-
 }

--- a/lib/Checkout/Payments/Four/Sender/PaymentIndividualSender.php
+++ b/lib/Checkout/Payments/Four/Sender/PaymentIndividualSender.php
@@ -2,6 +2,8 @@
 
 namespace Checkout\Payments\Four\Sender;
 
+use Checkout\Common\Address;
+
 class PaymentIndividualSender extends PaymentSender
 {
     public function __construct()
@@ -9,14 +11,23 @@ class PaymentIndividualSender extends PaymentSender
         parent::__construct(PaymentSenderType::$individual);
     }
 
+    /**
+     * @var string
+     */
     public $fist_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $address;
 
-    // Identification
+    /**
+     * @var Identification
+     */
     public $identification;
-
 }

--- a/lib/Checkout/Payments/Four/Sender/PaymentSender.php
+++ b/lib/Checkout/Payments/Four/Sender/PaymentSender.php
@@ -4,11 +4,13 @@ namespace Checkout\Payments\Four\Sender;
 
 class PaymentSender
 {
+    /**
+     * @var PaymentSenderType
+     */
     public $type;
 
     public function __construct($type)
     {
         $this->type = $type;
     }
-
 }

--- a/lib/Checkout/Payments/Hosted/HostedPaymentsSessionRequest.php
+++ b/lib/Checkout/Payments/Hosted/HostedPaymentsSessionRequest.php
@@ -2,70 +2,147 @@
 
 namespace Checkout\Payments\Hosted;
 
+use Checkout\Common\Currency;
+use Checkout\Common\CustomerRequest;
+use Checkout\Common\MarketplaceData;
+use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Product;
+use Checkout\Payments\BillingDescriptor;
+use Checkout\Payments\BillingInformation;
+use Checkout\Payments\PaymentRecipient;
+use Checkout\Payments\PaymentType;
+use Checkout\Payments\ProcessingSettings;
+use Checkout\Payments\RiskRequest;
+use Checkout\Payments\ShippingDetails;
+use Checkout\Payments\ThreeDsRequest;
+use DateTime;
+
 class HostedPaymentsSessionRequest
 {
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var string
+     */
     public $description;
 
-    // CustomerRequest
+    /**
+     * @var CustomerRequest
+     */
     public $customer;
 
-    // ShippingDetails
+    /**
+     * @var ShippingDetails
+     */
     public $shipping;
 
-    // BillingInformation
+    /**
+     * @var BillingInformation
+     */
     public $billing;
 
-    // PaymentRecipient
+    /**
+     * @var PaymentRecipient
+     */
     public $recipient;
 
-    // ProcessingSettings
+    /**
+     * @var ProcessingSettings
+     */
     public $processing;
 
-    // Product
+    /**
+     * @var array of Product
+     */
     public $products;
 
+    /**
+     * @var array
+     */
     public $metadata;
 
-    // ThreeDsRequest
+    /**
+     * @var ThreeDsRequest
+     */
     public $three_ds;
 
-    // RiskRequest
+    /**
+     * @var RiskRequest
+     */
     public $risk;
 
+    /**
+     * @var string
+     */
     public $success_url;
 
+    /**
+     * @var string
+     */
     public $cancel_url;
 
+    /**
+     * @var string
+     */
     public $failure_url;
 
+    /**
+     * @var string
+     */
     public $locale;
 
+    /**
+     * @var bool
+     */
     public $capture;
 
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $capture_on;
 
+    /**
+     * @var PaymentType
+     */
     public $payment_type;
 
+    /**
+     * @var string
+     */
     public $payment_ip;
 
-    // BillingDescriptor
+    /**
+     * @var BillingDescriptor
+     */
     public $billing_descriptor;
 
-    //PaymentSourceType
+    /**
+     * @var PaymentSourceType
+     */
     public $allow_payment_methods;
 
     // Only available in Four
 
+    /**
+     * @var string
+     */
     public $processing_channel_id;
 
-    // MarketplaceData
+    /**
+     * @var MarketplaceData
+     */
     public $marketplace;
-
 }

--- a/lib/Checkout/Payments/Links/PaymentLinkRequest.php
+++ b/lib/Checkout/Payments/Links/PaymentLinkRequest.php
@@ -2,67 +2,140 @@
 
 namespace Checkout\Payments\Links;
 
+use Checkout\Common\Currency;
+use Checkout\Common\CustomerRequest;
+use Checkout\Common\MarketplaceData;
+use Checkout\Payments\BillingDescriptor;
+use Checkout\Payments\BillingInformation;
+use Checkout\Payments\PaymentRecipient;
+use Checkout\Payments\PaymentType;
+use Checkout\Payments\ProcessingSettings;
+use Checkout\Payments\RiskRequest;
+use Checkout\Payments\ShippingDetails;
+use Checkout\Payments\ThreeDsRequest;
+use DateTime;
+
 class PaymentLinkRequest
 {
-
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var string
+     */
     public $description;
 
+    /**
+     * @var int
+     */
     public $expires_in;
 
-    // CustomerRequest
+    /**
+     * @var CustomerRequest
+     */
     public $customer;
 
-    // ShippingDetails
+    /**
+     * @var ShippingDetails
+     */
     public $shipping;
 
-    // BillingInformation
+    /**
+     * @var BillingInformation
+     */
     public $billing;
 
-    // PaymentRecipient
+    /**
+     * @var PaymentRecipient
+     */
     public $recipient;
 
-    // ProcessingSettings
+    /**
+     * @var ProcessingSettings
+     */
     public $processing;
 
-    // Product
+    /**
+     * @var array of Product
+     */
     public $products;
 
-    // RiskRequest
+    /**
+     * @var RiskRequest
+     */
     public $risk;
 
+    /**
+     * @var string
+     */
     public $return_url;
 
+    /**
+     * @var array
+     */
     public $metadata;
 
+    /**
+     * @var string
+     */
     public $locale;
 
-    // ThreeDsRequest
+    /**
+     * @var ThreeDsRequest
+     */
     public $three_ds;
 
+    /**
+     * @var bool
+     */
     public $capture;
 
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $capture_on;
 
+    /**
+     * @var PaymentType
+     */
     public $payment_type;
 
+    /**
+     * @var string
+     */
     public $payment_ip;
 
-    // BillingDescriptor
+    /**
+     * @var BillingDescriptor
+     */
     public $billing_descriptor;
 
+    /**
+     * @var array of PaymentSourceType
+     */
     public $allow_payment_methods;
 
     // Only available in Four
 
+    /**
+     * @var string
+     */
     public $processing_channel_id;
 
-    // MarketplaceData
+    /**
+     * @var MarketplaceData
+     */
     public $marketplace;
 }

--- a/lib/Checkout/Payments/PaymentRecipient.php
+++ b/lib/Checkout/Payments/PaymentRecipient.php
@@ -2,18 +2,37 @@
 
 namespace Checkout\Payments;
 
+use Checkout\Common\Country;
+
 class PaymentRecipient
 {
+    /**
+     * @var string
+     */
     public $dob;
 
+    /**
+     * @var string
+     */
     public $account_number;
 
+    /**
+     * @var string
+     */
     public $zip;
 
+    /**
+     * @var string
+     */
     public $first_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
 
+    /**
+     * @var Country
+     */
     public $country;
-
 }

--- a/lib/Checkout/Payments/PaymentRequest.php
+++ b/lib/Checkout/Payments/PaymentRequest.php
@@ -2,54 +2,111 @@
 
 namespace Checkout\Payments;
 
+use Checkout\Common\Currency;
+use Checkout\Common\CustomerRequest;
+use Checkout\Payments\Source\AbstractRequestSource;
+use DateTime;
+
 class PaymentRequest
 {
-    // AbstractRequestSource
+    /**
+     * @var AbstractRequestSource
+     */
     public $source;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
+    /**
+     * @var PaymentType
+     */
     public $payment_type;
 
+    /**
+     * @var bool
+     */
     public $merchant_initiated;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var string
+     */
     public $description;
 
+    /**
+     * @var bool
+     */
     public $capture;
 
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $capture_on;
 
-    // CustomerRequest
+    /**
+     * @var CustomerRequest
+     */
     public $customer;
 
-    // BillingDescriptor
+    /**
+     * @var BillingDescriptor
+     */
     public $billing_descriptor;
 
-    // ShippingDetails
+    /**
+     * @var ShippingDetails
+     */
     public $shipping;
 
+    /**
+     * @var string
+     */
     public $previous_payment_id;
 
-    // RiskRequest
+    /**
+     * @var RiskRequest
+     */
     public $risk;
 
+    /**
+     * @var string
+     */
     public $success_url;
 
+    /**
+     * @var string
+     */
     public $failure_url;
 
+    /**
+     * @var string
+     */
     public $payment_ip;
 
-    // ThreeDsRequest
+    /**
+     * @var ThreeDsRequest
+     */
     public $three_ds;
 
-    // PaymentRecipient
+    /**
+     * @var PaymentRecipient
+     */
     public $recipient;
 
+    /**
+     * @var array
+     */
     public $metadata;
 
     /**

--- a/lib/Checkout/Payments/PayoutRequest.php
+++ b/lib/Checkout/Payments/PayoutRequest.php
@@ -2,55 +2,115 @@
 
 namespace Checkout\Payments;
 
+use Checkout\Common\Currency;
+use Checkout\Common\CustomerRequest;
+use Checkout\Payments\Destination\PaymentRequestDestination;
+use DateTime;
+
 class PayoutRequest
 {
-    // PaymentRequestDestination
+    /**
+     * @var PaymentRequestDestination
+     */
     public $destination;
 
+    /**
+     * @var int
+     */
     public $amount;
 
-    // FundTransferType
+    /**
+     * @var FundTransferType
+     */
     public $fund_transfer_type;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
+    /**
+     * @var PaymentType
+     */
     public $payment_type;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var string
+     */
     public $description;
 
+    /**
+     * @var bool
+     */
     public $capture;
 
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $capture_on;
 
-    // CustomerRequest
+    /**
+     * @var CustomerRequest
+     */
     public $customer;
 
-    // BillingDescriptor
+    /**
+     * @var BillingDescriptor
+     */
     public $billing_descriptor;
 
-    // ShippingDetails
+    /**
+     * @var ShippingDetails
+     */
     public $shipping;
 
+    /**
+     * @var string
+     */
     public $previous_payment_id;
 
-    // RiskRequest
+    /**
+     * @var RiskRequest
+     */
     public $risk;
 
+    /**
+     * @var string
+     */
     public $success_url;
 
+    /**
+     * @var string
+     */
     public $failure_url;
 
+    /**
+     * @var string
+     */
     public $payment_ip;
 
+    /**
+     * @var string
+     */
     public $purpose;
 
-    // PaymentRecipient
+    /**
+     * @var PaymentRecipient
+     */
     public $recipient;
 
+    /**
+     * @var array
+     */
     public $metadata;
 
+    /**
+     * @var array
+     */
     public $processing;
 }

--- a/lib/Checkout/Payments/ProcessingSettings.php
+++ b/lib/Checkout/Payments/ProcessingSettings.php
@@ -4,10 +4,19 @@ namespace Checkout\Payments;
 
 class ProcessingSettings
 {
+    /**
+     * @var bool
+     */
     public $aft;
 
+    /**
+     * @var int
+     */
     public $tax_amount;
 
+    /**
+     * @var int
+     */
     public $shipping_amount;
 
     /**

--- a/lib/Checkout/Payments/RefundRequest.php
+++ b/lib/Checkout/Payments/RefundRequest.php
@@ -4,10 +4,18 @@ namespace Checkout\Payments;
 
 class RefundRequest
 {
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var array
+     */
     public $metadata;
-
 }

--- a/lib/Checkout/Payments/RiskRequest.php
+++ b/lib/Checkout/Payments/RiskRequest.php
@@ -4,5 +4,8 @@ namespace Checkout\Payments;
 
 class RiskRequest
 {
+    /**
+     * @var bool
+     */
     public $enabled;
 }

--- a/lib/Checkout/Payments/ShippingDetails.php
+++ b/lib/Checkout/Payments/ShippingDetails.php
@@ -2,12 +2,18 @@
 
 namespace Checkout\Payments;
 
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
+
 class ShippingDetails
 {
-    // Address
+    /**
+     * @var Address
+     */
     public $address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/Source/AbstractRequestSource.php
+++ b/lib/Checkout/Payments/Source/AbstractRequestSource.php
@@ -2,8 +2,13 @@
 
 namespace Checkout\Payments\Source;
 
+use Checkout\Common\PaymentSourceType;
+
 abstract class AbstractRequestSource
 {
+    /**
+     * @var PaymentSourceType
+     */
     public $type;
 
     public function __construct($type)

--- a/lib/Checkout/Payments/Source/Apm/BalotoPayer.php
+++ b/lib/Checkout/Payments/Source/Apm/BalotoPayer.php
@@ -4,7 +4,13 @@ namespace Checkout\Payments\Source\Apm;
 
 class BalotoPayer
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $email;
 }

--- a/lib/Checkout/Payments/Source/Apm/FawryProduct.php
+++ b/lib/Checkout/Payments/Source/Apm/FawryProduct.php
@@ -4,12 +4,23 @@ namespace Checkout\Payments\Source\Apm;
 
 class FawryProduct
 {
+    /**
+     * @var string
+     */
     public $product_id;
 
+    /**
+     * @var int
+     */
     public $quantity;
 
+    /**
+     * @var int
+     */
     public $price;
 
+    /**
+     * @var string
+     */
     public $description;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/KlarnaCustomer.php
+++ b/lib/Checkout/Payments/Source/Apm/KlarnaCustomer.php
@@ -4,7 +4,13 @@ namespace Checkout\Payments\Source\Apm;
 
 class KlarnaCustomer
 {
+    /**
+     * @var string
+     */
     public $date_of_birth;
 
+    /**
+     * @var string
+     */
     public $gender;
 }

--- a/lib/Checkout/Payments/Source/Apm/KlarnaProduct.php
+++ b/lib/Checkout/Payments/Source/Apm/KlarnaProduct.php
@@ -4,16 +4,33 @@ namespace Checkout\Payments\Source\Apm;
 
 class KlarnaProduct
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var int
+     */
     public $quantity;
 
+    /**
+     * @var int
+     */
     public $unit_price;
 
+    /**
+     * @var int
+     */
     public $tax_rate;
 
+    /**
+     * @var int
+     */
     public $total_amount;
 
+    /**
+     * @var int
+     */
     public $total_tax_amount;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/Payer.php
+++ b/lib/Checkout/Payments/Source/Apm/Payer.php
@@ -4,10 +4,18 @@ namespace Checkout\Payments\Source\Apm;
 
 class Payer
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $email;
 
+    /**
+     * @var string
+     */
     public $document;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestBalotoSource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestBalotoSource.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Payments\Source\Apm;
 
+use Checkout\Common\Country;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Source\AbstractRequestSource;
 
@@ -13,13 +14,23 @@ class RequestBalotoSource extends AbstractRequestSource
         $this->integration_type = IntegrationType::$redirect;
     }
 
+    /**
+     * @var IntegrationType
+     */
     public $integration_type;
 
+    /**
+     * @var Country
+     */
     public $country;
 
+    /**
+     * @var string
+     */
     public $description;
 
-    // BalotoPayer
+    /**
+     * @var BalotoPayer
+     */
     public $payer;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestBoletoSource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestBoletoSource.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Payments\Source\Apm;
 
+use Checkout\Common\Country;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Source\AbstractRequestSource;
 
@@ -13,12 +14,23 @@ class RequestBoletoSource extends AbstractRequestSource
         $this->integration_type = IntegrationType::$redirect;
     }
 
+    /**
+     * @var IntegrationType
+     */
     public $integration_type;
 
+    /**
+     * @var Country
+     */
     public $country;
 
+    /**
+     * @var string
+     */
     public $description;
 
-    // Payer
+    /**
+     * @var Payer
+     */
     public $payer;
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestFawrySource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestFawrySource.php
@@ -12,13 +12,23 @@ class RequestFawrySource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$fawry);
     }
 
+    /**
+     * @var string
+     */
     public $description;
 
+    /**
+     * @var string
+     */
     public $customer_mobile;
 
+    /**
+     * @var string
+     */
     public $customer_email;
 
-    // FawryProduct
+    /**
+     * @var array of FawryProduct
+     */
     public $products;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestGiropaySource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestGiropaySource.php
@@ -12,5 +12,8 @@ class RequestGiropaySource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$giropay);
     }
 
+    /**
+     * @var string
+     */
     public $purpose;
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestIdealSource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestIdealSource.php
@@ -12,10 +12,18 @@ class RequestIdealSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$ideal);
     }
 
+    /**
+     * @var string
+     */
     public $bic;
 
+    /**
+     * @var string
+     */
     public $description;
 
+    /**
+     * @var string
+     */
     public $language;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestKlarnaSource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestKlarnaSource.php
@@ -2,6 +2,8 @@
 
 namespace Checkout\Payments\Source\Apm;
 
+use Checkout\Common\Address;
+use Checkout\Common\Country;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Source\AbstractRequestSource;
 
@@ -12,20 +14,38 @@ class RequestKlarnaSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$klarna);
     }
 
+    /**
+     * @var string
+     */
     public $authorization_token;
 
+    /**
+     * @var string
+     */
     public $locale;
 
+    /**
+     * @var Country
+     */
     public $purchase_country;
 
+    /**
+     * @var int
+     */
     public $tax_amount;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // KlarnaCustomer
+    /**
+     * @var KlarnaCustomer
+     */
     public $customer;
 
-    // array KlarnaProduct
+    /**
+     * @var array of KlarnaProduct
+     */
     public $products;
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestOxxoSource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestOxxoSource.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Payments\Source\Apm;
 
+use Checkout\Common\Country;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Source\AbstractRequestSource;
 
@@ -13,13 +14,23 @@ class RequestOxxoSource extends AbstractRequestSource
         $this->integration_type = IntegrationType::$redirect;
     }
 
+    /**
+     * @var IntegrationType
+     */
     public $integration_type;
 
+    /**
+     * @var Country
+     */
     public $country;
 
-    // Payer
+    /**
+     * @var Payer
+     */
     public $payer;
 
+    /**
+     * @var string
+     */
     public $description;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestPagoFacilSource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestPagoFacilSource.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Payments\Source\Apm;
 
+use Checkout\Common\Country;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Source\AbstractRequestSource;
 
@@ -13,13 +14,23 @@ class RequestPagoFacilSource extends AbstractRequestSource
         $this->integration_type = IntegrationType::$redirect;
     }
 
+    /**
+     * @var IntegrationType
+     */
     public $integration_type;
 
+    /**
+     * @var Country
+     */
     public $country;
 
-    // Payer
+    /**
+     * @var Payer
+     */
     public $payer;
 
+    /**
+     * @var string
+     */
     public $description;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestRapiPagoSource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestRapiPagoSource.php
@@ -2,6 +2,7 @@
 
 namespace Checkout\Payments\Source\Apm;
 
+use Checkout\Common\Country;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Source\AbstractRequestSource;
 
@@ -13,13 +14,23 @@ class RequestRapiPagoSource extends AbstractRequestSource
         $this->integration_type = IntegrationType::$redirect;
     }
 
+    /**
+     * @var IntegrationType
+     */
     public $integration_type;
 
+    /**
+     * @var Country
+     */
     public $country;
 
-    // Payer
+    /**
+     * @var Payer
+     */
     public $payer;
 
+    /**
+     * @var string
+     */
     public $description;
-
 }

--- a/lib/Checkout/Payments/Source/Apm/RequestSepaSource.php
+++ b/lib/Checkout/Payments/Source/Apm/RequestSepaSource.php
@@ -12,5 +12,8 @@ class RequestSepaSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$id);
     }
 
+    /**
+     * @var string
+     */
     public $id;
 }

--- a/lib/Checkout/Payments/Source/RequestCardSource.php
+++ b/lib/Checkout/Payments/Source/RequestCardSource.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Payments\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class RequestCardSource extends AbstractRequestSource
 {
@@ -12,22 +14,43 @@ class RequestCardSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$card);
     }
 
+    /**
+     * @var string
+     */
     public $number;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $cvv;
 
+    /**
+     * @var bool
+     */
     public $stored;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/Source/RequestCustomerSource.php
+++ b/lib/Checkout/Payments/Source/RequestCustomerSource.php
@@ -12,5 +12,8 @@ class RequestCustomerSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$customer);
     }
 
+    /**
+     * @var string
+     */
     public $id;
 }

--- a/lib/Checkout/Payments/Source/RequestDLocalSource.php
+++ b/lib/Checkout/Payments/Source/RequestDLocalSource.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Payments\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class RequestDLocalSource extends AbstractRequestSource
 {
@@ -12,21 +14,43 @@ class RequestDLocalSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$dlocal);
     }
 
+    /**
+     * @var string
+     */
     public $number;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $cvv;
 
+    /**
+     * @var bool
+     */
     public $stored;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
 }

--- a/lib/Checkout/Payments/Source/RequestIdSource.php
+++ b/lib/Checkout/Payments/Source/RequestIdSource.php
@@ -12,8 +12,13 @@ class RequestIdSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$id);
     }
 
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $cvv;
-
 }

--- a/lib/Checkout/Payments/Source/RequestNetworkTokenSource.php
+++ b/lib/Checkout/Payments/Source/RequestNetworkTokenSource.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Payments\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class RequestNetworkTokenSource extends AbstractRequestSource
 {
@@ -12,28 +14,58 @@ class RequestNetworkTokenSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$network_token);
     }
 
+    /**
+     * @var string
+     */
     public $token;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $token_type;
 
+    /**
+     * @var string
+     */
     public $cryptogram;
 
+    /**
+     * @var string
+     */
     public $eci;
 
+    /**
+     * @var bool
+     */
     public $stored;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $cvv;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/Source/RequestTokenSource.php
+++ b/lib/Checkout/Payments/Source/RequestTokenSource.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Payments\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class RequestTokenSource extends AbstractRequestSource
 {
@@ -12,12 +14,18 @@ class RequestTokenSource extends AbstractRequestSource
         parent::__construct(PaymentSourceType::$token);
     }
 
+    /**
+     * @var string
+     */
     public $token;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Payments/ThreeDsRequest.php
+++ b/lib/Checkout/Payments/ThreeDsRequest.php
@@ -2,22 +2,48 @@
 
 namespace Checkout\Payments;
 
+use Checkout\Common\ChallengeIndicatorType;
+use Checkout\Common\Exemption;
+
 class ThreeDsRequest
 {
+    /**
+     * @var bool
+     */
     public $enabled = true;
 
+    /**
+     * @var bool
+     */
     public $attempt_n3d;
 
+    /**
+     * @var string
+     */
     public $eci;
 
+    /**
+     * @var string
+     */
     public $cryptogram;
 
+    /**
+     * @var string
+     */
     public $xid;
 
+    /**
+     * @var string
+     */
     public $version;
 
+    /**
+     * @var Exemption
+     */
     public $exemption;
 
+    /**
+     * @var ChallengeIndicatorType
+     */
     public $challenge_indicator;
-
 }

--- a/lib/Checkout/Payments/VoidRequest.php
+++ b/lib/Checkout/Payments/VoidRequest.php
@@ -4,8 +4,13 @@ namespace Checkout\Payments;
 
 class VoidRequest
 {
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var array
+     */
     public $metadata;
-
 }

--- a/lib/Checkout/Reconciliation/ReconciliationQueryPaymentsFilter.php
+++ b/lib/Checkout/Reconciliation/ReconciliationQueryPaymentsFilter.php
@@ -6,7 +6,13 @@ use Checkout\Common\QueryFilterDateRange;
 
 class ReconciliationQueryPaymentsFilter extends QueryFilterDateRange
 {
+    /**
+     * @var int
+     */
     public $limit;
 
+    /**
+     * @var string
+     */
     public $reference;
 }

--- a/lib/Checkout/Risk/Device.php
+++ b/lib/Checkout/Risk/Device.php
@@ -2,23 +2,47 @@
 
 namespace Checkout\Risk;
 
+use DateTime;
+
 class Device
 {
+    /**
+     * @var string
+     */
     public $ip;
 
-    // Location
+    /**
+     * @var Location
+     */
     public $location;
 
+    /**
+     * @var string
+     */
     public $os;
 
+    /**
+     * @var string
+     */
     public $type;
 
+    /**
+     * @var string
+     */
     public $model;
 
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $date;
 
+    /**
+     * @var string
+     */
     public $user_agent;
 
+    /**
+     * @var string
+     */
     public $fingerprint;
 }

--- a/lib/Checkout/Risk/Location.php
+++ b/lib/Checkout/Risk/Location.php
@@ -4,7 +4,13 @@ namespace Checkout\Risk;
 
 class Location
 {
+    /**
+     * @var string
+     */
     public $latitude;
 
+    /**
+     * @var string
+     */
     public $longitude;
 }

--- a/lib/Checkout/Risk/PreAuthentication/PreAuthenticationAssessmentRequest.php
+++ b/lib/Checkout/Risk/PreAuthentication/PreAuthenticationAssessmentRequest.php
@@ -2,33 +2,68 @@
 
 namespace Checkout\Risk\PreAuthentication;
 
+use Checkout\Common\Currency;
+use Checkout\Common\CustomerRequest;
+use Checkout\Risk\Device;
+use Checkout\Risk\RiskPayment;
+use Checkout\Risk\RiskShippingDetails;
+use Checkout\Risk\Source\RiskPaymentRequestSource;
+use DateTime;
+
 class PreAuthenticationAssessmentRequest
 {
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $date;
 
-    // RiskPaymentRequestSource
+    /**
+     * @var RiskPaymentRequestSource
+     */
     public $source;
 
-    // CustomerRequest
+    /**
+     * @var CustomerRequest
+     */
     public $customer;
 
-    // RiskPayment
+    /**
+     * @var RiskPayment
+     */
     public $payment;
 
-    // RiskShippingDetails
+    /**
+     * @var RiskShippingDetails
+     */
     public $shipping;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var string
+     */
     public $description;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
-    // Device
+    /**
+     * @var Device
+     */
     public $device;
 
+    /**
+     * @var array
+     */
     public $metadata;
 }

--- a/lib/Checkout/Risk/PreCapture/AuthenticationResult.php
+++ b/lib/Checkout/Risk/PreCapture/AuthenticationResult.php
@@ -4,15 +4,33 @@ namespace Checkout\Risk\PreCapture;
 
 class AuthenticationResult
 {
+    /**
+     * @var bool
+     */
     public $attempted;
 
+    /**
+     * @var bool
+     */
     public $challenged;
 
+    /**
+     * @var bool
+     */
     public $succeeded;
 
+    /**
+     * @var bool
+     */
     public $liability_shifted;
 
+    /**
+     * @var string
+     */
     public $method;
 
+    /**
+     * @var string
+     */
     public $version;
 }

--- a/lib/Checkout/Risk/PreCapture/AuthorizationResult.php
+++ b/lib/Checkout/Risk/PreCapture/AuthorizationResult.php
@@ -4,7 +4,13 @@ namespace Checkout\Risk\PreCapture;
 
 class AuthorizationResult
 {
+    /**
+     * @var string
+     */
     public $avs_code;
 
+    /**
+     * @var string
+     */
     public $cvv_result;
 }

--- a/lib/Checkout/Risk/PreCapture/PreCaptureAssessmentRequest.php
+++ b/lib/Checkout/Risk/PreCapture/PreCaptureAssessmentRequest.php
@@ -2,37 +2,73 @@
 
 namespace Checkout\Risk\PreCapture;
 
+use Checkout\Common\Currency;
+use Checkout\Common\CustomerRequest;
+use Checkout\Risk\Device;
+use Checkout\Risk\RiskPayment;
+use Checkout\Risk\RiskShippingDetails;
+use Checkout\Risk\Source\RiskPaymentRequestSource;
+use DateTime;
+
 class PreCaptureAssessmentRequest
 {
+    /**
+     * @var string
+     */
     public $assessment_id;
 
-    // DateTime
+    /**
+     * @var DateTime
+     */
     public $date;
 
-    // RiskPaymentRequestSource
+    /**
+     * @var RiskPaymentRequestSource
+     */
     public $source;
 
-    // CustomerRequest
+    /**
+     * @var CustomerRequest
+     */
     public $customer;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
-    // RiskPayment
+    /**
+     * @var RiskPayment
+     */
     public $payment;
 
-    // RiskShippingDetails
+    /**
+     * @var RiskShippingDetails
+     */
     public $shipping;
 
-    // Device
+    /**
+     * @var Device
+     */
     public $device;
 
+    /**
+     * @var array
+     */
     public $metadata;
 
-    // AuthenticationResult
+    /**
+     * @var AuthenticationResult
+     */
     public $authentication_result;
 
-    // AuthorizationResult
+    /**
+     * @var AuthorizationResult
+     */
     public $authorization_result;
 }

--- a/lib/Checkout/Risk/RiskPayment.php
+++ b/lib/Checkout/Risk/RiskPayment.php
@@ -4,7 +4,13 @@ namespace Checkout\Risk;
 
 class RiskPayment
 {
+    /**
+     * @var string
+     */
     public $psp;
 
+    /**
+     * @var string
+     */
     public $id;
 }

--- a/lib/Checkout/Risk/RiskShippingDetails.php
+++ b/lib/Checkout/Risk/RiskShippingDetails.php
@@ -2,8 +2,12 @@
 
 namespace Checkout\Risk;
 
+use Checkout\Common\Address;
+
 class RiskShippingDetails
 {
-    // Address
+    /**
+     * @var Address
+     */
     public $address;
 }

--- a/lib/Checkout/Risk/Source/CardSourcePrism.php
+++ b/lib/Checkout/Risk/Source/CardSourcePrism.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Risk\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class CardSourcePrism extends RiskPaymentRequestSource
 {
@@ -11,18 +13,33 @@ class CardSourcePrism extends RiskPaymentRequestSource
         parent::__construct(PaymentSourceType::$card);
     }
 
+    /**
+     * @var string
+     */
     public $number;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $name;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Risk/Source/CustomerSourcePrism.php
+++ b/lib/Checkout/Risk/Source/CustomerSourcePrism.php
@@ -6,12 +6,13 @@ use Checkout\Common\PaymentSourceType;
 
 class CustomerSourcePrism extends RiskPaymentRequestSource
 {
+    /**
+     * @var string
+     */
     public $id;
 
     public function __construct()
     {
         parent::__construct(PaymentSourceType::$customer);
     }
-
-
 }

--- a/lib/Checkout/Risk/Source/IdSourcePrism.php
+++ b/lib/Checkout/Risk/Source/IdSourcePrism.php
@@ -6,15 +6,18 @@ use Checkout\Common\PaymentSourceType;
 
 class IdSourcePrism extends RiskPaymentRequestSource
 {
-
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $cvv;
 
     public function __construct()
     {
         parent::__construct(PaymentSourceType::$id);
     }
-
-
 }

--- a/lib/Checkout/Risk/Source/RiskPaymentRequestSource.php
+++ b/lib/Checkout/Risk/Source/RiskPaymentRequestSource.php
@@ -2,13 +2,17 @@
 
 namespace Checkout\Risk\Source;
 
+use Checkout\Common\PaymentSourceType;
+
 abstract class RiskPaymentRequestSource
 {
+    /**
+     * @var PaymentSourceType
+     */
     public $type;
 
     public function __construct($type)
     {
         $this->type = $type;
     }
-
 }

--- a/lib/Checkout/Risk/Source/RiskRequestTokenSource.php
+++ b/lib/Checkout/Risk/Source/RiskRequestTokenSource.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Risk\Source;
 
+use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
+use Checkout\Common\Phone;
 
 class RiskRequestTokenSource extends RiskPaymentRequestSource
 {
@@ -12,12 +14,18 @@ class RiskRequestTokenSource extends RiskPaymentRequestSource
         parent::__construct(PaymentSourceType::$token);
     }
 
+    /**
+     * @var string
+     */
     public $token;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Sessions/Channel/AppSession.php
+++ b/lib/Checkout/Sessions/Channel/AppSession.php
@@ -10,21 +10,43 @@ class AppSession extends ChannelData
         parent::__construct(ChannelType::$app);
     }
 
+    /**
+     * @var string
+     */
     public $sdk_app_id;
 
+    /**
+     * @var int
+     */
     public $sdk_max_timeout;
 
-    // SdkEphemeralPublicKey
+    /**
+     * @var SdkEphemeralPublicKey
+     */
     public $sdk_ephem_pub_key;
 
+    /**
+     * @var string
+     */
     public $sdk_reference_number;
 
+    /**
+     * @var string
+     */
     public $sdk_encrypted_data;
 
+    /**
+     * @var string
+     */
     public $sdk_transaction_id;
 
+    /**
+     * @var SdkInterfaceType
+     */
     public $sdk_interface_type;
 
+    /**
+     * @var array of UIElements
+     */
     public $sdk_ui_elements;
-
 }

--- a/lib/Checkout/Sessions/Channel/BrowserSession.php
+++ b/lib/Checkout/Sessions/Channel/BrowserSession.php
@@ -10,24 +10,53 @@ class BrowserSession extends ChannelData
         parent::__construct(ChannelType::$browser);
     }
 
+    /**
+     * @var ThreeDsMethodCompletion
+     */
     public $three_ds_method_completion;
 
+    /**
+     * @var string
+     */
     public $accept_header;
 
+    /**
+     * @var bool
+     */
     public $java_enabled;
 
+    /**
+     * @var string
+     */
     public $language;
 
+    /**
+     * @var string
+     */
     public $color_depth;
 
+    /**
+     * @var string
+     */
     public $screen_height;
 
+    /**
+     * @var string
+     */
     public $screen_width;
 
+    /**
+     * @var string
+     */
     public $timezone;
 
+    /**
+     * @var string
+     */
     public $user_agent;
 
+    /**
+     * @var string
+     */
     public $ip_address;
-
 }

--- a/lib/Checkout/Sessions/Channel/ChannelData.php
+++ b/lib/Checkout/Sessions/Channel/ChannelData.php
@@ -9,6 +9,8 @@ abstract class ChannelData
         $this->channel = $channel;
     }
 
+    /**
+     * @var ChannelType
+     */
     public $channel;
-
 }

--- a/lib/Checkout/Sessions/Channel/SdkEphemeralPublicKey.php
+++ b/lib/Checkout/Sessions/Channel/SdkEphemeralPublicKey.php
@@ -4,11 +4,23 @@ namespace Checkout\Sessions\Channel;
 
 class SdkEphemeralPublicKey
 {
+    /**
+     * @var string
+     */
     public $kty;
 
+    /**
+     * @var string
+     */
     public $crv;
 
+    /**
+     * @var string
+     */
     public $x;
 
+    /**
+     * @var string
+     */
     public $y;
 }

--- a/lib/Checkout/Sessions/Completion/CompletionInfo.php
+++ b/lib/Checkout/Sessions/Completion/CompletionInfo.php
@@ -9,6 +9,8 @@ abstract class CompletionInfo
         $this->type = $type;
     }
 
+    /**
+     * @var CompletionInfoType
+     */
     public $type;
-
 }

--- a/lib/Checkout/Sessions/Completion/HostedCompletionInfo.php
+++ b/lib/Checkout/Sessions/Completion/HostedCompletionInfo.php
@@ -9,10 +9,18 @@ class HostedCompletionInfo extends CompletionInfo
         parent::__construct(CompletionInfoType::$hosted);
     }
 
+    /**
+     * @var string
+     */
     public $callback_url;
 
+    /**
+     * @var string
+     */
     public $success_url;
 
+    /**
+     * @var string
+     */
     public $failure_url;
-
 }

--- a/lib/Checkout/Sessions/Completion/NonHostedCompletionInfo.php
+++ b/lib/Checkout/Sessions/Completion/NonHostedCompletionInfo.php
@@ -9,6 +9,8 @@ class NonHostedCompletionInfo extends CompletionInfo
         parent::__construct(CompletionInfoType::$nonHosted);
     }
 
+    /**
+     * @var string
+     */
     public $callback_url;
-
 }

--- a/lib/Checkout/Sessions/SessionAddress.php
+++ b/lib/Checkout/Sessions/SessionAddress.php
@@ -6,5 +6,8 @@ use Checkout\Common\Address;
 
 class SessionAddress extends Address
 {
+    /**
+     * @var string
+     */
     public $address_line3;
 }

--- a/lib/Checkout/Sessions/SessionMarketplaceData.php
+++ b/lib/Checkout/Sessions/SessionMarketplaceData.php
@@ -4,5 +4,8 @@ namespace Checkout\Sessions;
 
 class SessionMarketplaceData
 {
+    /**
+     * @var string
+     */
     public $sub_entity_id;
 }

--- a/lib/Checkout/Sessions/SessionRequest.php
+++ b/lib/Checkout/Sessions/SessionRequest.php
@@ -2,40 +2,81 @@
 
 namespace Checkout\Sessions;
 
+use Checkout\Common\ChallengeIndicatorType;
+use Checkout\Common\Currency;
+use Checkout\Sessions\Channel\ChannelData;
+use Checkout\Sessions\Completion\CompletionInfo;
+use Checkout\Sessions\Source\SessionSource;
+
 class SessionRequest
 {
-    // SessionSource
+    /**
+     * @var SessionSource
+     */
     public $source;
 
+    /**
+     * @var int
+     */
     public $amount;
 
+    /**
+     * @var Currency
+     */
     public $currency;
 
+    /**
+     * @var string
+     */
     public $processing_channel_id;
 
-    // SessionMarketplaceData
+    /**
+     * @var SessionMarketplaceData
+     */
     public $marketplace;
 
+    /**
+     * @var AuthenticationType
+     */
     public $authentication_type;
 
+    /**
+     * @var Category
+     */
     public $authentication_category;
 
+    /**
+     * @var ChallengeIndicatorType
+     */
     public $challenge_indicator;
 
-    // SessionsBillingDescriptor
+    /**
+     * @var SessionsBillingDescriptor
+     */
     public $billing_descriptor;
 
+    /**
+     * @var string
+     */
     public $reference;
 
+    /**
+     * @var TransactionType
+     */
     public $transaction_type;
 
-    // SessionAddress
+    /**
+     * @var SessionAddress
+     */
     public $shipping_address;
 
-    // CompletionInfo
+    /**
+     * @var CompletionInfo
+     */
     public $completion;
 
-    // ChannelData
+    /**
+     * @var ChannelData
+     */
     public $channel_data;
-
 }

--- a/lib/Checkout/Sessions/SessionsBillingDescriptor.php
+++ b/lib/Checkout/Sessions/SessionsBillingDescriptor.php
@@ -4,5 +4,8 @@ namespace Checkout\Sessions;
 
 class SessionsBillingDescriptor
 {
+    /**
+     * @var string
+     */
     public $name;
 }

--- a/lib/Checkout/Sessions/Source/RequestTokenSource.php
+++ b/lib/Checkout/Sessions/Source/RequestTokenSource.php
@@ -11,6 +11,8 @@ class RequestTokenSource extends SessionSource
         parent::__construct(SessionSourceType::$token);
     }
 
+    /**
+     * @var string
+     */
     public $token;
-
 }

--- a/lib/Checkout/Sessions/Source/SessionCardSource.php
+++ b/lib/Checkout/Sessions/Source/SessionCardSource.php
@@ -12,14 +12,28 @@ class SessionCardSource extends SessionSource
         parent::__construct(SessionSourceType::$card);
     }
 
+    /**
+     * @var string
+     */
     public $number;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $email;
-
 }

--- a/lib/Checkout/Sessions/Source/SessionSource.php
+++ b/lib/Checkout/Sessions/Source/SessionSource.php
@@ -2,6 +2,11 @@
 
 namespace Checkout\Sessions\Source;
 
+use Checkout\Common\Phone;
+use Checkout\Sessions\SessionAddress;
+use Checkout\Sessions\SessionScheme;
+use Checkout\Sessions\SessionSourceType;
+
 abstract class SessionSource
 {
     public function __construct($type)
@@ -9,17 +14,33 @@ abstract class SessionSource
         $this->type = $type;
     }
 
+    /**
+     * @var SessionSourceType
+     */
     public $type;
 
-    // SessionAddress
+    /**
+     * @var SessionAddress
+     */
     public $billing_address;
 
+    /**
+     * @var Phone
+     */
     public $home_phone;
 
+    /**
+     * @var Phone
+     */
     public $mobile_phone;
 
+    /**
+     * @var Phone
+     */
     public $work_phone;
 
-    // SessionScheme
+    /**
+     * @var SessionScheme
+     */
     public $scheme;
 }

--- a/lib/Checkout/Sessions/Source/SessionsRequestIdSource.php
+++ b/lib/Checkout/Sessions/Source/SessionsRequestIdSource.php
@@ -11,6 +11,8 @@ class SessionsRequestIdSource extends SessionSource
         parent::__construct(SessionSourceType::$id);
     }
 
+    /**
+     * @var string
+     */
     public $id;
-
 }

--- a/lib/Checkout/Sessions/ThreeDsMethodCompletionRequest.php
+++ b/lib/Checkout/Sessions/ThreeDsMethodCompletionRequest.php
@@ -2,7 +2,12 @@
 
 namespace Checkout\Sessions;
 
+use Checkout\Sessions\Channel\ThreeDsMethodCompletion;
+
 class ThreeDsMethodCompletionRequest
 {
+    /**
+     * @var ThreeDsMethodCompletion
+     */
     public $three_ds_method_completion;
 }

--- a/lib/Checkout/Sources/SepaSourceRequest.php
+++ b/lib/Checkout/Sources/SepaSourceRequest.php
@@ -2,18 +2,22 @@
 
 namespace Checkout\Sources;
 
+use Checkout\Common\Address;
+
 class SepaSourceRequest extends SourceRequest
 {
-
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // SourceData
+    /**
+     * @var SourceData
+     */
     public $source_data;
 
     public function __construct()
     {
         parent::__construct(SourceType::$sepa);
     }
-
 }

--- a/lib/Checkout/Sources/SourceData.php
+++ b/lib/Checkout/Sources/SourceData.php
@@ -4,15 +4,33 @@ namespace Checkout\Sources;
 
 class SourceData
 {
+    /**
+     * @var string
+     */
     public $first_name;
 
+    /**
+     * @var string
+     */
     public $last_name;
 
+    /**
+     * @var string
+     */
     public $account_iban;
 
+    /**
+     * @var string
+     */
     public $bic;
 
+    /**
+     * @var string
+     */
     public $billing_descriptor;
 
+    /**
+     * @var string
+     */
     public $mandate_type;
 }

--- a/lib/Checkout/Sources/SourceRequest.php
+++ b/lib/Checkout/Sources/SourceRequest.php
@@ -2,21 +2,33 @@
 
 namespace Checkout\Sources;
 
+use Checkout\Common\CustomerRequest;
+use Checkout\Common\Phone;
+
 abstract class SourceRequest
 {
+    /**
+     * @var SourceType
+     */
     public $type;
 
+    /**
+     * @var string
+     */
     public $reference;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
 
-    // CustomerRequest
+    /**
+     * @var CustomerRequest
+     */
     public $customer;
 
     public function __construct($type)
     {
         $this->type = $type;
     }
-
 }

--- a/lib/Checkout/StaticKeysCheckoutSdkBuilder.php
+++ b/lib/Checkout/StaticKeysCheckoutSdkBuilder.php
@@ -8,11 +8,17 @@ class StaticKeysCheckoutSdkBuilder extends AbstractStaticKeysCheckoutSdkBuilder
     const PUBLIC_KEY_PATTERN = "/^pk_(test_)?(\\w{8})-(\\w{4})-(\\w{4})-(\\w{4})-(\\w{12})$/";
     const SECRET_KEY_PATTERN = "/^sk_(test_)?(\\w{8})-(\\w{4})-(\\w{4})-(\\w{4})-(\\w{12})$/";
 
+    /**
+     * @param string $publicKey
+     */
     public function setPublicKey($publicKey)
     {
         $this->publicKey = $publicKey;
     }
 
+    /**
+     * @param string $secretKey
+     */
     public function setSecretKey($secretKey)
     {
         $this->secretKey = $secretKey;

--- a/lib/Checkout/Tokens/ApplePayTokenData.php
+++ b/lib/Checkout/Tokens/ApplePayTokenData.php
@@ -4,11 +4,23 @@ namespace Checkout\Tokens;
 
 class ApplePayTokenData
 {
+    /**
+     * @var string
+     */
     public $version;
 
+    /**
+     * @var string
+     */
     public $data;
 
+    /**
+     * @var string
+     */
     public $signature;
 
+    /**
+     * @var array
+     */
     public $header;
 }

--- a/lib/Checkout/Tokens/ApplePayTokenRequest.php
+++ b/lib/Checkout/Tokens/ApplePayTokenRequest.php
@@ -9,7 +9,8 @@ class ApplePayTokenRequest extends WalletTokenRequest
         parent::__construct(TokenType::$applepay);
     }
 
-    // ApplePayTokenData
+    /**
+     * @var ApplePayTokenData
+     */
     public $token_data;
-
 }

--- a/lib/Checkout/Tokens/CardTokenRequest.php
+++ b/lib/Checkout/Tokens/CardTokenRequest.php
@@ -2,24 +2,48 @@
 
 namespace Checkout\Tokens;
 
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
+
 class CardTokenRequest
 {
+    /**
+     * @var string
+     */
     public $type = "card";
 
+    /**
+     * @var string
+     */
     public $number;
 
+    /**
+     * @var int
+     */
     public $expiry_month;
 
+    /**
+     * @var int
+     */
     public $expiry_year;
 
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var string
+     */
     public $cvv;
 
-    // Address
+    /**
+     * @var Address
+     */
     public $billing_address;
 
-    // Phone
+    /**
+     * @var Phone
+     */
     public $phone;
-
 }

--- a/lib/Checkout/Tokens/GooglePayTokenData.php
+++ b/lib/Checkout/Tokens/GooglePayTokenData.php
@@ -4,9 +4,18 @@ namespace Checkout\Tokens;
 
 class GooglePayTokenData
 {
+    /**
+     * @var string
+     */
     public $signature;
 
+    /**
+     * @var string
+     */
     public $protocolVersion;
 
+    /**
+     * @var string
+     */
     public $signedMessage;
 }

--- a/lib/Checkout/Tokens/GooglePayTokenRequest.php
+++ b/lib/Checkout/Tokens/GooglePayTokenRequest.php
@@ -9,7 +9,8 @@ class GooglePayTokenRequest extends WalletTokenRequest
         parent::__construct(TokenType::$googlepay);
     }
 
-    // GooglePayTokenData
+    /**
+     * @var GooglePayTokenData
+     */
     public $token_data;
-
 }

--- a/lib/Checkout/Tokens/WalletTokenRequest.php
+++ b/lib/Checkout/Tokens/WalletTokenRequest.php
@@ -4,6 +4,9 @@ namespace Checkout\Tokens;
 
 abstract class WalletTokenRequest
 {
+    /**
+     * @var TokenType
+     */
     public $type;
 
     protected function __construct($type)

--- a/lib/Checkout/Webhooks/WebhookRequest.php
+++ b/lib/Checkout/Webhooks/WebhookRequest.php
@@ -4,13 +4,28 @@ namespace Checkout\Webhooks;
 
 class WebhookRequest
 {
+    /**
+     * @var string
+     */
     public $url;
 
+    /**
+     * @var bool
+     */
     public $active;
 
+    /**
+     * @var array
+     */
     public $headers;
 
+    /**
+     * @var string
+     */
     public $content_type;
 
+    /**
+     * @var array
+     */
     public $event_types;
 }

--- a/lib/Checkout/Workflows/Actions/WebhookSignature.php
+++ b/lib/Checkout/Workflows/Actions/WebhookSignature.php
@@ -4,7 +4,13 @@ namespace Checkout\Workflows\Actions;
 
 class WebhookSignature
 {
+    /**
+     * @var string
+     */
     public $method;
 
+    /**
+     * @var string
+     */
     public $key;
 }

--- a/lib/Checkout/Workflows/Actions/WebhookWorkflowActionRequest.php
+++ b/lib/Checkout/Workflows/Actions/WebhookWorkflowActionRequest.php
@@ -4,10 +4,19 @@ namespace Checkout\Workflows\Actions;
 
 class WebhookWorkflowActionRequest extends WorkflowActionRequest
 {
+    /**
+     * @var string
+     */
     public $url;
 
+    /**
+     * @var array
+     */
     public $headers;
 
+    /**
+     * @var WebhookSignature
+     */
     public $signature;
 
     public function __construct()

--- a/lib/Checkout/Workflows/Actions/WorkflowActionRequest.php
+++ b/lib/Checkout/Workflows/Actions/WorkflowActionRequest.php
@@ -4,6 +4,9 @@ namespace Checkout\Workflows\Actions;
 
 abstract class WorkflowActionRequest
 {
+    /**
+     * @var WorkflowActionType
+     */
     public $type;
 
     protected function __construct($type)

--- a/lib/Checkout/Workflows/Conditions/EntityWorkflowConditionRequest.php
+++ b/lib/Checkout/Workflows/Conditions/EntityWorkflowConditionRequest.php
@@ -4,6 +4,9 @@ namespace Checkout\Workflows\Conditions;
 
 class EntityWorkflowConditionRequest extends WorkflowConditionRequest
 {
+    /**
+     * @var array
+     */
     public $entities;
 
     public function __construct()

--- a/lib/Checkout/Workflows/Conditions/EventWorkflowConditionRequest.php
+++ b/lib/Checkout/Workflows/Conditions/EventWorkflowConditionRequest.php
@@ -4,6 +4,9 @@ namespace Checkout\Workflows\Conditions;
 
 class EventWorkflowConditionRequest extends WorkflowConditionRequest
 {
+    /**
+     * @var array
+     */
     public $events;
 
     public function __construct()

--- a/lib/Checkout/Workflows/Conditions/ProcessingChannelWorkflowConditionRequest.php
+++ b/lib/Checkout/Workflows/Conditions/ProcessingChannelWorkflowConditionRequest.php
@@ -4,6 +4,9 @@ namespace Checkout\Workflows\Conditions;
 
 class ProcessingChannelWorkflowConditionRequest extends WorkflowConditionRequest
 {
+    /**
+     * @var array
+     */
     public $processing_channels;
 
     public function __construct()

--- a/lib/Checkout/Workflows/Conditions/WorkflowConditionRequest.php
+++ b/lib/Checkout/Workflows/Conditions/WorkflowConditionRequest.php
@@ -4,6 +4,9 @@ namespace Checkout\Workflows\Conditions;
 
 abstract class WorkflowConditionRequest
 {
+    /**
+     * @var WorkflowConditionType
+     */
     public $type;
 
     protected function __construct($type)

--- a/lib/Checkout/Workflows/CreateWorkflowRequest.php
+++ b/lib/Checkout/Workflows/CreateWorkflowRequest.php
@@ -4,11 +4,23 @@ namespace Checkout\Workflows;
 
 class CreateWorkflowRequest
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var bool
+     */
     public $active;
 
+    /**
+     * @var array of WorkflowConditionRequest
+     */
     public $conditions;
 
+    /**
+     * @var array of WorkflowActionRequest
+     */
     public $actions;
 }

--- a/lib/Checkout/Workflows/Events/Event.php
+++ b/lib/Checkout/Workflows/Events/Event.php
@@ -4,9 +4,18 @@ namespace Checkout\Workflows\Events;
 
 class Event
 {
+    /**
+     * @var string
+     */
     public $id;
 
+    /**
+     * @var string
+     */
     public $display_name;
 
+    /**
+     * @var string
+     */
     public $description;
 }

--- a/lib/Checkout/Workflows/Reflows/ReflowByEventsRequest.php
+++ b/lib/Checkout/Workflows/Reflows/ReflowByEventsRequest.php
@@ -4,5 +4,8 @@ namespace Checkout\Workflows\Reflows;
 
 class ReflowByEventsRequest extends ReflowRequest
 {
+    /**
+     * @var array
+     */
     public $events;
 }

--- a/lib/Checkout/Workflows/Reflows/ReflowBySubjectsRequest.php
+++ b/lib/Checkout/Workflows/Reflows/ReflowBySubjectsRequest.php
@@ -4,5 +4,8 @@ namespace Checkout\Workflows\Reflows;
 
 class ReflowBySubjectsRequest extends ReflowRequest
 {
+    /**
+     * @var array
+     */
     public $subjects;
 }

--- a/lib/Checkout/Workflows/Reflows/ReflowRequest.php
+++ b/lib/Checkout/Workflows/Reflows/ReflowRequest.php
@@ -4,5 +4,8 @@ namespace Checkout\Workflows\Reflows;
 
 abstract class ReflowRequest
 {
+    /**
+     * @var array
+     */
     public $workflows;
 }

--- a/lib/Checkout/Workflows/UpdateWorkflowRequest.php
+++ b/lib/Checkout/Workflows/UpdateWorkflowRequest.php
@@ -4,7 +4,13 @@ namespace Checkout\Workflows;
 
 class UpdateWorkflowRequest
 {
+    /**
+     * @var string
+     */
     public $name;
 
+    /**
+     * @var bool
+     */
     public $active;
 }

--- a/test/Checkout/Tests/Payments/RequestPayoutsIntegrationTest.php
+++ b/test/Checkout/Tests/Payments/RequestPayoutsIntegrationTest.php
@@ -66,8 +66,8 @@ class RequestPayoutsIntegrationTest extends AbstractPaymentsIntegrationTest
             "destination.last4",
             "destination.fingerprint",
             "destination.name",
-            "destination.issuer",
-            "destination.issuer_country",
+            //"destination.issuer",
+            //"destination.issuer_country",
             "destination.product_id",
             "destination.product_type"
         );

--- a/test/Checkout/Tests/SandboxTestFixture.php
+++ b/test/Checkout/Tests/SandboxTestFixture.php
@@ -2,8 +2,11 @@
 
 namespace Checkout\Tests;
 
+use Checkout\CheckoutApi;
+use Checkout\CheckoutArgumentException;
 use Checkout\CheckoutAuthorizationException;
 use Checkout\CheckoutDefaultSdk;
+use Checkout\CheckoutException;
 use Checkout\CheckoutFourSdk;
 use Checkout\Common\Address;
 use Checkout\Common\Country;
@@ -20,7 +23,13 @@ use PHPUnit\Framework\TestCase;
 abstract class SandboxTestFixture extends TestCase
 {
 
+    /**
+     * @var CheckoutApi
+     */
     protected $defaultApi;
+    /**
+     * @var \Checkout\Four\CheckoutApi
+     */
     protected $fourApi;
 
     const MESSAGE_404 = "The API response status code (404) does not indicate success.";
@@ -28,6 +37,11 @@ abstract class SandboxTestFixture extends TestCase
 
     private $logger;
 
+    /**
+     * @throws CheckoutAuthorizationException
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
     protected function init($platformType)
     {
         $this->logger = new Logger("checkout-sdk-test-php");
@@ -88,16 +102,25 @@ abstract class SandboxTestFixture extends TestCase
         }
     }
 
+    /**
+     * @return string
+     */
     protected function randomEmail()
     {
         return uniqid() . "@checkout-sdk-net.com";
     }
 
+    /**
+     * @return false|string
+     */
     protected function idempotencyKey()
     {
         return substr(uniqid(), 0, 8);
     }
 
+    /**
+     * @return string
+     */
     public static function getCheckoutFilePath()
     {
         return __DIR__ . DIRECTORY_SEPARATOR . "Resources" . DIRECTORY_SEPARATOR . "checkout.jpeg";


### PR DESCRIPTION
Due to the support for old PHP versions (5.6+) we lost the ability to enforce the type object on all the classes, we added the hint support based on Docs to make more easy the integration of the SDK, without opening classes to understand the type of the object.