### PR TITLE
Remove `purpose` from root `PayoutRequest`

### DIFF
--- a/lib/Checkout/Payments/PayoutRequest.php
+++ b/lib/Checkout/Payments/PayoutRequest.php
@@ -95,11 +95,6 @@ class PayoutRequest
     public $payment_ip;
 
     /**
-     * @var string
-     */
-    public $purpose;
-
-    /**
      * @var PaymentRecipient
      */
     public $recipient;


### PR DESCRIPTION
Property purpose must be added in `processing`.