### PR TITLE
fix: phpdoc $idempotencyKey type

### DIFF
--- a/lib/Checkout/Transfers/TransfersClient.php
+++ b/lib/Checkout/Transfers/TransfersClient.php
@@ -19,11 +19,11 @@ class TransfersClient extends Client
 
     /**
      * @param CreateTransferRequest $transferRequest
-     * @param null $idempotencyKey
+     * @param string|null $idempotencyKey
      * @return array
      * @throws CheckoutApiException
      */
-    public function initiateTransferOfFunds(CreateTransferRequest $transferRequest, $idempotencyKey = null)
+    public function initiateTransferOfFunds(CreateTransferRequest $transferRequest, string $idempotencyKey = null)
     {
         return $this->apiClient->post(
             self::TRANSFERS_PATH,


### PR DESCRIPTION
string type is missing from the phpdoc, phpstan raises an error :

`Parameter $idempotencyKey of method Checkout\Transfers\TransfersClient::initiateTransferOfFunds() expects null, string given.`