### PR TITLE
Implement retrieve files endpoint in Platforms API

### DIFF
--- a/lib/Checkout/Accounts/AccountsClient.php
+++ b/lib/Checkout/Accounts/AccountsClient.php
@@ -17,6 +17,7 @@ class AccountsClient extends Client
     const ENTITIES_PATH = "entities";
     const PAYOUT_SCHEDULES_PATH = "payout-schedules";
     const PAYMENT_INSTRUMENTS_PATH = "payment-instruments";
+    const PLATFORMS_FILES_PATH = "platforms-files";
 
     private $filesApiClient;
 
@@ -39,20 +40,6 @@ class AccountsClient extends Client
         return $this->apiClient->post(
             $this->buildPath(self::ACCOUNTS_PATH, self::ENTITIES_PATH),
             $entityRequest,
-            $this->sdkAuthorization()
-        );
-    }
-
-    /**
-     * @param string $entityId
-     * @param string $paymentInstrumentId
-     * @return array
-     * @throws CheckoutApiException
-     */
-    public function retrievePaymentInstrumentDetails($entityId, $paymentInstrumentId)
-    {
-        return $this->apiClient->get(
-            $this->buildPath(self::ACCOUNTS_PATH, self::ENTITIES_PATH, $entityId, self::PAYMENT_INSTRUMENTS_PATH, $paymentInstrumentId),
             $this->sdkAuthorization()
         );
     }
@@ -86,6 +73,33 @@ class AccountsClient extends Client
     }
 
     /**
+     * @param PlatformsFileRequest $fileRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function updateAFile(PlatformsFileRequest $fileRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::PLATFORMS_FILES_PATH),
+            $fileRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param $fileId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function retrieveAFile($fileId)
+    {
+        return $this->apiClient->get(
+            $this->buildPath(self::PLATFORMS_FILES_PATH, $fileId),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
      * @param $entityId
      * @param AccountsPaymentInstrument $accountsPaymentInstrument
      * @return array
@@ -112,6 +126,20 @@ class AccountsClient extends Client
         return $this->apiClient->post(
             $this->buildPath(self::ACCOUNTS_PATH, self::ENTITIES_PATH, $entityId, self::PAYMENT_INSTRUMENTS_PATH),
             $instrumentRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $entityId
+     * @param string $paymentInstrumentId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function retrievePaymentInstrumentDetails($entityId, $paymentInstrumentId)
+    {
+        return $this->apiClient->get(
+            $this->buildPath(self::ACCOUNTS_PATH, self::ENTITIES_PATH, $entityId, self::PAYMENT_INSTRUMENTS_PATH, $paymentInstrumentId),
             $this->sdkAuthorization()
         );
     }
@@ -154,6 +182,7 @@ class AccountsClient extends Client
      * @param AccountsFileRequest $accountsFileRequest
      * @return array
      * @throws CheckoutApiException
+     * @deprecated This endpoint is no longer supported officially, please check the documentation.
      */
     public function submitFile(AccountsFileRequest $accountsFileRequest)
     {

--- a/lib/Checkout/Accounts/PlatformsFileRequest.php
+++ b/lib/Checkout/Accounts/PlatformsFileRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class PlatformsFileRequest
+{
+    /**
+     * @var string
+     */
+    public $purpose;
+
+    /**
+     * @var string
+     */
+    public $entity_id;
+}

--- a/test/Checkout/Tests/Accounts/AccountsClientTest.php
+++ b/test/Checkout/Tests/Accounts/AccountsClientTest.php
@@ -8,6 +8,7 @@ use Checkout\Accounts\AccountsPaymentInstrument;
 use Checkout\Accounts\OnboardEntityRequest;
 use Checkout\Accounts\PaymentInstrumentRequest;
 use Checkout\Accounts\PaymentInstrumentsQuery;
+use Checkout\Accounts\PlatformsFileRequest;
 use Checkout\Accounts\UpdatePaymentInstrumentRequest;
 use Checkout\Accounts\UpdateScheduleRequest;
 use Checkout\CheckoutApiException;
@@ -79,6 +80,36 @@ class AccountsClientTest extends UnitTestFixture
             ->willReturn("response");
 
         $response = $this->client->UpdateEntity("entity_id", new OnboardEntityRequest());
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldUpdateAFile()
+    {
+        $this->apiClient
+            ->method("post")
+            ->willReturn("response");
+
+        $response = $this->client->UpdateAFile(new PlatformsFileRequest());
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldRetrieveAFile()
+    {
+        $this->apiClient
+            ->method("get")
+            ->willReturn("response");
+
+        $response = $this->client->RetrieveAFile("file_id");
 
         $this->assertNotNull($response);
     }

--- a/test/Checkout/Tests/Accounts/AccountsIntegrationTest.php
+++ b/test/Checkout/Tests/Accounts/AccountsIntegrationTest.php
@@ -14,6 +14,7 @@ use Checkout\Accounts\InstrumentDocument;
 use Checkout\Accounts\OnboardEntityRequest;
 use Checkout\Accounts\PaymentInstrumentRequest;
 use Checkout\Accounts\PaymentInstrumentsQuery;
+use Checkout\Accounts\PlatformsFileRequest;
 use Checkout\Accounts\Profile;
 use Checkout\Accounts\Representative;
 use Checkout\CheckoutApi;
@@ -97,6 +98,63 @@ class AccountsIntegrationTest extends SandboxTestFixture
     /**
      * @test
      * @throws CheckoutApiException
+     */
+    public function shouldUpdateAndGetAFile()
+    {
+        $this->markTestSkipped("unavailable");
+        $onboardEntityRequest = new OnboardEntityRequest();
+        $onboardEntityRequest->reference = uniqid();
+        $emailAddresses = new EntityEmailAddresses();
+        $emailAddresses->primary = $this->randomEmail();
+        $onboardEntityRequest->contact_details = new ContactDetails();
+        $onboardEntityRequest->contact_details->phone = $this->getPhone();
+        $onboardEntityRequest->contact_details->email_addresses = $emailAddresses;
+        $onboardEntityRequest->profile = new Profile();
+        $onboardEntityRequest->profile->urls = array("https://www.superheroexample.com");
+        $onboardEntityRequest->profile->mccs = array("0742");
+        $onboardEntityRequest->individual = new Individual();
+        $onboardEntityRequest->individual->first_name = "Bruce";
+        $onboardEntityRequest->individual->last_name = "Wayne";
+        $onboardEntityRequest->individual->trading_name = "Batman's Super Hero Masks";
+        $onboardEntityRequest->individual->registered_address = $this->getAddress();
+        $onboardEntityRequest->individual->national_tax_id = "TAX123456";
+        $onboardEntityRequest->individual->date_of_birth = $this->getDateOfBirth();
+        $onboardEntityRequest->individual->identification = $this->getTestIdentification();
+
+        $response = $this->checkoutApi->getAccountsClient()->createEntity($onboardEntityRequest);
+
+        $request = new PlatformsFileRequest();
+        $request->purpose = "identity_verification";
+        $request->entity_id = $response["id"];
+
+        $updateResponse = $this->checkoutApi->getAccountsClient()->updateAFile($request);
+
+        $this->assertResponse(
+            $updateResponse,
+            "id",
+            "status",
+            "maximum_size_in_bytes",
+            "document_types_for_purpose"
+        );
+
+        $retrieveResponse = $this->checkoutApi->getAccountsClient()->retrieveAFile($updateResponse["Id"]);
+
+        $this->assertResponse(
+            $retrieveResponse,
+            "id",
+            "status",
+            "status_reasons",
+            "file_name",
+            "size",
+            "mime_type",
+            "uploaded_on",
+            "purpose"
+        );
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
      * @throws CheckoutArgumentException
      * @throws CheckoutException
      */
@@ -170,6 +228,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
     /**
      * @test
      * @throws CheckoutApiException
+     * @deprecated Obsolete
      */
     public function shouldUploadAccountsFile()
     {
@@ -213,6 +272,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
     /**
      * @return array
      * @throws CheckoutApiException
+     * @deprecated Obsolete
      */
     public function uploadFile()
     {


### PR DESCRIPTION
## Implement retrieve files endpoint in Platforms API
Add:
- Upload A File endpoint
- Retrieve A File endpoint

![image](https://user-images.githubusercontent.com/2817124/219415592-1d43eb47-09f4-42c4-bc21-b2d4cf8c8930.png)

Labeled as obsolete:
- SubmitFile method

## API reference
- https://api-reference.checkout.com/#operation/uploadAFile
- https://api-reference.checkout.com/#operation/retrieveAFile

### Notice: `PUT` not implemented
https://www.checkout.com/docs/platforms/onboarding/api/full/upload-a-file#Types_of_identification_and_requirements_1