### PR TITLE
Adds support for Card operations [Issuing] (CS2)

### DIFF
--- a/lib/Checkout/Issuing/CardType.php
+++ b/lib/Checkout/Issuing/CardType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Checkout\Issuing;
+
+class CardType
+{
+    public static $physical = "physical";
+    public static $virtual = "virtual";
+}

--- a/lib/Checkout/Issuing/Cards/Create/CardLifetime.php
+++ b/lib/Checkout/Issuing/Cards/Create/CardLifetime.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Create;
+
+class CardLifetime
+{
+    /**
+     * @var string value of LifetimeUnit
+     */
+    public $unit;
+
+    /**
+     * @var int
+     */
+    public $value;
+
+}

--- a/lib/Checkout/Issuing/Cards/Create/CardRequest.php
+++ b/lib/Checkout/Issuing/Cards/Create/CardRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Create;
+
+abstract class CardRequest
+{
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @var string value of CardType
+     */
+    public $type;
+
+    /**
+     * @var string
+     */
+    public $cardholder_id;
+
+    /**
+     * @var CardLifetime
+     */
+    public $lifetime;
+
+    /**
+     * @var string
+     */
+    public $reference;
+
+    /**
+     * @var string
+     */
+    public $card_product_id;
+
+    /**
+     * @var string
+     */
+    public $display_name;
+
+    /**
+     * @var bool
+     */
+    public $activate_card;
+}

--- a/lib/Checkout/Issuing/Cards/Create/CardRequest.php
+++ b/lib/Checkout/Issuing/Cards/Create/CardRequest.php
@@ -4,7 +4,7 @@ namespace Checkout\Issuing\Cards\Create;
 
 abstract class CardRequest
 {
-    public function __construct($type)
+    protected function __construct($type)
     {
         $this->type = $type;
     }

--- a/lib/Checkout/Issuing/Cards/Create/LifetimeUnit.php
+++ b/lib/Checkout/Issuing/Cards/Create/LifetimeUnit.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Create;
+
+class LifetimeUnit
+{
+    public static $months = "Months";
+    public static $years = "Years";
+}

--- a/lib/Checkout/Issuing/Cards/Create/PhysicalCardRequest.php
+++ b/lib/Checkout/Issuing/Cards/Create/PhysicalCardRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Create;
+
+use Checkout\Issuing\CardType;
+
+class PhysicalCardRequest extends CardRequest
+{
+    public function __construct()
+    {
+        parent::__construct(CardType::$physical);
+    }
+
+    /**
+     * @var ShippingInstructions
+     */
+    public $shipping_instructions;
+}

--- a/lib/Checkout/Issuing/Cards/Create/ShippingInstructions.php
+++ b/lib/Checkout/Issuing/Cards/Create/ShippingInstructions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Create;
+
+use Checkout\Common\Address;
+
+class ShippingInstructions
+{
+    /**
+     * @var string
+     */
+    public $recipient_address;
+
+    /**
+     * @var Address
+     */
+    public $shipping_address;
+
+    /**
+     * @var string
+     */
+    public $additional_comment;
+}

--- a/lib/Checkout/Issuing/Cards/Create/VirtualCardRequest.php
+++ b/lib/Checkout/Issuing/Cards/Create/VirtualCardRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Create;
+
+use Checkout\Issuing\CardType;
+
+class VirtualCardRequest extends CardRequest
+{
+    public function __construct()
+    {
+        parent::__construct(CardType::$virtual);
+    }
+
+    /**
+     * @var boolean
+     */
+    public $is_single_use;
+}

--- a/lib/Checkout/Issuing/Cards/Credentials/CardCredentialsQuery.php
+++ b/lib/Checkout/Issuing/Cards/Credentials/CardCredentialsQuery.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Credentials;
+
+use Checkout\Common\AbstractQueryFilter;
+
+class CardCredentialsQuery extends AbstractQueryFilter
+{
+    /**
+     * @var string
+     */
+    public $credentials;
+}

--- a/lib/Checkout/Issuing/Cards/Enrollment/PasswordThreeDSEnrollmentRequest.php
+++ b/lib/Checkout/Issuing/Cards/Enrollment/PasswordThreeDSEnrollmentRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Enrollment;
+
+class PasswordThreeDSEnrollmentRequest extends ThreeDSEnrollmentRequest
+{
+    /**
+     * @var string
+     */
+    public $password;
+}

--- a/lib/Checkout/Issuing/Cards/Enrollment/SecurityPair.php
+++ b/lib/Checkout/Issuing/Cards/Enrollment/SecurityPair.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Enrollment;
+
+class SecurityPair
+{
+    /**
+     * @var string
+     */
+    public $question;
+
+    /**
+     * @var string
+     */
+    public $answer;
+}

--- a/lib/Checkout/Issuing/Cards/Enrollment/SecurityQuestionThreeDSEnrollmentRequest.php
+++ b/lib/Checkout/Issuing/Cards/Enrollment/SecurityQuestionThreeDSEnrollmentRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Enrollment;
+
+class SecurityQuestionThreeDSEnrollmentRequest extends ThreeDSEnrollmentRequest
+{
+    /**
+     * @var SecurityPair
+     */
+    public $security_pair;
+}

--- a/lib/Checkout/Issuing/Cards/Enrollment/ThreeDSEnrollmentRequest.php
+++ b/lib/Checkout/Issuing/Cards/Enrollment/ThreeDSEnrollmentRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Enrollment;
+
+use Checkout\Common\Phone;
+
+abstract class ThreeDSEnrollmentRequest
+{
+    /**
+     * @var string
+     */
+    public $locale;
+
+    /**
+     * @var Phone
+     */
+    public $phone_number;
+}

--- a/lib/Checkout/Issuing/Cards/Enrollment/UpdateThreeDSEnrollmentRequest.php
+++ b/lib/Checkout/Issuing/Cards/Enrollment/UpdateThreeDSEnrollmentRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Enrollment;
+
+use Checkout\Common\Phone;
+
+class UpdateThreeDSEnrollmentRequest
+{
+    /**
+     * @var SecurityPair
+     */
+    public $security_pair;
+
+    /**
+     * @var string
+     */
+    public $password;
+
+    /**
+     * @var string
+     */
+    public $locale;
+
+    /**
+     * @var Phone
+     */
+    public $phone_number;
+}

--- a/lib/Checkout/Issuing/Cards/Revoke/RevokeCardRequest.php
+++ b/lib/Checkout/Issuing/Cards/Revoke/RevokeCardRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Revoke;
+
+class RevokeCardRequest
+{
+    /**
+     * @var string value of RevokeReason
+     */
+    public $reason;
+}

--- a/lib/Checkout/Issuing/Cards/Revoke/RevokeReason.php
+++ b/lib/Checkout/Issuing/Cards/Revoke/RevokeReason.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Revoke;
+
+class RevokeReason
+{
+    public static $expired = "expired";
+    public static $reported_lost = "reported_lost";
+    public static $reported_stolen = "reported_stolen";
+}

--- a/lib/Checkout/Issuing/Cards/Suspend/SuspendCardRequest.php
+++ b/lib/Checkout/Issuing/Cards/Suspend/SuspendCardRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Suspend;
+
+class SuspendCardRequest
+{
+    /**
+     * @var string value of SuspendReason
+     */
+    public $reason;
+}

--- a/lib/Checkout/Issuing/Cards/Suspend/SuspendReason.php
+++ b/lib/Checkout/Issuing/Cards/Suspend/SuspendReason.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Checkout\Issuing\Cards\Suspend;
+
+class SuspendReason
+{
+    public static $suspected_lost = "suspected_lost";
+    public static $suspected_stolen = "suspected_stolen";
+}

--- a/lib/Checkout/Issuing/Controls/ControlType.php
+++ b/lib/Checkout/Issuing/Controls/ControlType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class ControlType
+{
+    public static $velocity_limit = "velocity_limit";
+    public static $mcc_limit = "mcc_limit";
+}

--- a/lib/Checkout/Issuing/Controls/Create/CardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Create/CardControlRequest.php
@@ -4,7 +4,7 @@ namespace Checkout\Issuing\Controls\Create;
 
 abstract class CardControlRequest
 {
-    public function __construct($type)
+    protected function __construct($type)
     {
         $this->control_type = $type;
     }

--- a/lib/Checkout/Issuing/Controls/Create/CardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Create/CardControlRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Create;
+
+abstract class CardControlRequest
+{
+    public function __construct($type)
+    {
+        $this->control_type = $type;
+    }
+
+    /**
+     * @var string value of ControlType
+     */
+    public $control_type;
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var string
+     */
+    public $target_id;
+}

--- a/lib/Checkout/Issuing/Controls/Create/MccCardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Create/MccCardControlRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Create;
+
+use Checkout\Issuing\Controls\ControlType;
+use Checkout\Issuing\Controls\MccLimit;
+
+class MccCardControlRequest extends CardControlRequest
+{
+    public function __construct()
+    {
+        parent::__construct(ControlType::$mcc_limit);
+    }
+
+    /**
+     * @var MccLimit
+     */
+    public $mcc_limit;
+}

--- a/lib/Checkout/Issuing/Controls/Create/VelocityCardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Create/VelocityCardControlRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Create;
+
+use Checkout\Issuing\Controls\ControlType;
+use Checkout\Issuing\Controls\VelocityLimit;
+
+class VelocityCardControlRequest extends CardControlRequest
+{
+    public function __construct()
+    {
+        parent::__construct(ControlType::$velocity_limit);
+    }
+
+    /**
+     * @var VelocityLimit
+     */
+    public $velocity_limit;
+}

--- a/lib/Checkout/Issuing/Controls/MccControlType.php
+++ b/lib/Checkout/Issuing/Controls/MccControlType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class MccControlType
+{
+    public static $allow = "allow";
+    public static $block = "block";
+}

--- a/lib/Checkout/Issuing/Controls/MccLimit.php
+++ b/lib/Checkout/Issuing/Controls/MccLimit.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class MccLimit
+{
+    /**
+     * @var string value of MccControlType
+     */
+    public $type;
+
+    /**
+     * @var array of string
+     */
+    public $mcc_list;
+}

--- a/lib/Checkout/Issuing/Controls/Query/CardControlsQuery.php
+++ b/lib/Checkout/Issuing/Controls/Query/CardControlsQuery.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Query;
+
+use Checkout\Common\AbstractQueryFilter;
+
+class CardControlsQuery extends AbstractQueryFilter
+{
+    /**
+     * @var string
+     */
+    public $target_id;
+}

--- a/lib/Checkout/Issuing/Controls/Update/UpdateCardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Update/UpdateCardControlRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Update;
+
+use Checkout\Issuing\Controls\MccLimit;
+use Checkout\Issuing\Controls\VelocityLimit;
+
+class UpdateCardControlRequest
+{
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var VelocityLimit
+     */
+    public $velocity_limit;
+
+    /**
+     * @var MccLimit
+     */
+    public $mcc_limit;
+}

--- a/lib/Checkout/Issuing/Controls/VelocityLimit.php
+++ b/lib/Checkout/Issuing/Controls/VelocityLimit.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class VelocityLimit
+{
+    /**
+     * @var int
+     */
+    public $amount_limit;
+
+    /**
+     * @var VelocityWindow
+     */
+    public $velocity_window;
+
+    /**
+     * @var array of string
+     */
+    public $mcc_list;
+}

--- a/lib/Checkout/Issuing/Controls/VelocityWindow.php
+++ b/lib/Checkout/Issuing/Controls/VelocityWindow.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class VelocityWindow
+{
+    /**
+     * @var string value of VelocityWindowType
+     */
+    public $type;
+}

--- a/lib/Checkout/Issuing/Controls/VelocityWindowType.php
+++ b/lib/Checkout/Issuing/Controls/VelocityWindowType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class VelocityWindowType
+{
+    public static $daily = "daily";
+    public static $weekly = "weekly";
+    public static $monthly = "monthly";
+    public static $all_time = "all_time";
+}

--- a/lib/Checkout/Issuing/IssuingClient.php
+++ b/lib/Checkout/Issuing/IssuingClient.php
@@ -14,6 +14,9 @@ use Checkout\Issuing\Cards\Enrollment\ThreeDSEnrollmentRequest;
 use Checkout\Issuing\Cards\Enrollment\UpdateThreeDSEnrollmentRequest;
 use Checkout\Issuing\Cards\Revoke\RevokeCardRequest;
 use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
+use Checkout\Issuing\Controls\Create\CardControlRequest;
+use Checkout\Issuing\Controls\Query\CardControlsQuery;
+use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
 
 class IssuingClient extends Client
 {
@@ -25,6 +28,7 @@ class IssuingClient extends Client
     const CREDENTIALS_PATH = "credentials";
     const REVOKE_PATH = "revoke";
     const SUSPEND_PATH = "suspend";
+    const CONTROLS_PATH = "controls";
 
     public function __construct(ApiClient $apiClient, CheckoutConfiguration $configuration)
     {
@@ -196,6 +200,75 @@ class IssuingClient extends Client
         return $this->apiClient->post(
             $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::SUSPEND_PATH),
             $suspendCardRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param CardControlRequest $cardControlRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function createControl(CardControlRequest $cardControlRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH),
+            $cardControlRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param CardControlsQuery $query
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getCardControls(CardControlsQuery $query)
+    {
+        return $this->apiClient->query(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH),
+            $query,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param $controlId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getCardControlDetails($controlId)
+    {
+        return $this->apiClient->get(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH, $controlId),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $controlId
+     * @param UpdateCardControlRequest $updateCardControlRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function updateCardControl($controlId, UpdateCardControlRequest $updateCardControlRequest)
+    {
+        return $this->apiClient->put(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH, $controlId),
+            $updateCardControlRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param $controlId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function removeCardControl($controlId)
+    {
+        return $this->apiClient->delete(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH, $controlId),
             $this->sdkAuthorization()
         );
     }

--- a/lib/Checkout/Issuing/IssuingClient.php
+++ b/lib/Checkout/Issuing/IssuingClient.php
@@ -8,14 +8,23 @@ use Checkout\CheckoutApiException;
 use Checkout\CheckoutConfiguration;
 use Checkout\Client;
 use Checkout\Issuing\Cardholders\CardholderRequest;
+use Checkout\Issuing\Cards\Create\CardRequest;
+use Checkout\Issuing\Cards\Credentials\CardCredentialsQuery;
+use Checkout\Issuing\Cards\Enrollment\ThreeDSEnrollmentRequest;
+use Checkout\Issuing\Cards\Enrollment\UpdateThreeDSEnrollmentRequest;
+use Checkout\Issuing\Cards\Revoke\RevokeCardRequest;
+use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
 
 class IssuingClient extends Client
 {
     const ISSUING_PATH = "issuing";
-
     const CARDHOLDERS_PATH = "cardholders";
-
     const CARDS_PATH = "cards";
+    const THREE_DS_PATH = "3ds-enrollment";
+    const ACTIVATE_PATH = "activate";
+    const CREDENTIALS_PATH = "credentials";
+    const REVOKE_PATH = "revoke";
+    const SUSPEND_PATH = "suspend";
 
     public function __construct(ApiClient $apiClient, CheckoutConfiguration $configuration)
     {
@@ -44,7 +53,7 @@ class IssuingClient extends Client
     public function getCardholder($cardholderId)
     {
         return $this->apiClient->get(
-            $this->buildPath($this->buildPath(self::ISSUING_PATH, self::CARDHOLDERS_PATH, $cardholderId)),
+            $this->buildPath(self::ISSUING_PATH, self::CARDHOLDERS_PATH, $cardholderId),
             $this->sdkAuthorization()
         );
     }
@@ -57,9 +66,136 @@ class IssuingClient extends Client
     public function getCardholderCards($cardholderId)
     {
         return $this->apiClient->get(
-            $this->buildPath(
-                $this->buildPath(self::ISSUING_PATH, self::CARDHOLDERS_PATH, $cardholderId, self::CARDS_PATH)
-            ),
+            $this->buildPath(self::ISSUING_PATH, self::CARDHOLDERS_PATH, $cardholderId, self::CARDS_PATH),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param CardRequest $cardRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function createCard(CardRequest $cardRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH),
+            $cardRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param $cardId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getCardDetails($cardId)
+    {
+        return $this->apiClient->get(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $cardId
+     * @param ThreeDSEnrollmentRequest $threeDSEnrollmentRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function enrollThreeDS($cardId, ThreeDSEnrollmentRequest $threeDSEnrollmentRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::THREE_DS_PATH),
+            $threeDSEnrollmentRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $cardId
+     * @param UpdateThreeDSEnrollmentRequest $threeDSEnrollmentRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function updateThreeDSEnrollment($cardId, UpdateThreeDSEnrollmentRequest $threeDSEnrollmentRequest)
+    {
+        return $this->apiClient->patch(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::THREE_DS_PATH),
+            $threeDSEnrollmentRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param $cardId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getCardThreeDSDetails($cardId)
+    {
+        return $this->apiClient->get(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::THREE_DS_PATH),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $cardId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function activateCard($cardId)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::ACTIVATE_PATH),
+            null,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $cardId
+     * @param CardCredentialsQuery $query
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getCardCredentials($cardId, CardCredentialsQuery $query)
+    {
+        return $this->apiClient->query(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::CREDENTIALS_PATH),
+            $query,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $cardId
+     * @param RevokeCardRequest $revokeCardRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function revokeCard($cardId, RevokeCardRequest $revokeCardRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::REVOKE_PATH),
+            $revokeCardRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $cardId
+     * @param SuspendCardRequest $suspendCardRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function suspendCard($cardId, SuspendCardRequest $suspendCardRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::SUSPEND_PATH),
+            $suspendCardRequest,
             $this->sdkAuthorization()
         );
     }

--- a/lib/Checkout/Issuing/IssuingClient.php
+++ b/lib/Checkout/Issuing/IssuingClient.php
@@ -17,6 +17,7 @@ use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
 use Checkout\Issuing\Controls\Create\CardControlRequest;
 use Checkout\Issuing\Controls\Query\CardControlsQuery;
 use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
+use Checkout\Issuing\Testing\CardAuthorizationRequest;
 
 class IssuingClient extends Client
 {
@@ -29,6 +30,8 @@ class IssuingClient extends Client
     const REVOKE_PATH = "revoke";
     const SUSPEND_PATH = "suspend";
     const CONTROLS_PATH = "controls";
+    const SIMULATE_PATH = "simulate";
+    const AUTHORIZATIONS_PATH = "authorizations";
 
     public function __construct(ApiClient $apiClient, CheckoutConfiguration $configuration)
     {
@@ -269,6 +272,20 @@ class IssuingClient extends Client
     {
         return $this->apiClient->delete(
             $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH, $controlId),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param CardAuthorizationRequest $authorizationRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function simulateAuthorization(CardAuthorizationRequest $authorizationRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::SIMULATE_PATH, self::AUTHORIZATIONS_PATH),
+            $authorizationRequest,
             $this->sdkAuthorization()
         );
     }

--- a/lib/Checkout/Issuing/Testing/CardAuthorizationRequest.php
+++ b/lib/Checkout/Issuing/Testing/CardAuthorizationRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Checkout\Issuing\Testing;
+
+class CardAuthorizationRequest
+{
+    /**
+     * @var CardSimulation
+     */
+    public $card;
+
+    /**
+     * @var TransactionSimulation
+     */
+    public $transaction;
+}

--- a/lib/Checkout/Issuing/Testing/CardSimulation.php
+++ b/lib/Checkout/Issuing/Testing/CardSimulation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Checkout\Issuing\Testing;
+
+class CardSimulation
+{
+    /**
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @var int
+     */
+    public $expiry_month;
+
+    /**
+     * @var int
+     */
+    public $expiry_year;
+}

--- a/lib/Checkout/Issuing/Testing/TransactionSimulation.php
+++ b/lib/Checkout/Issuing/Testing/TransactionSimulation.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Checkout\Issuing\Testing;
+
+use Checkout\Common\Currency;
+
+class TransactionSimulation
+{
+    /**
+     * @var string value of TransactionType
+     */
+    public $type;
+
+    /**
+     * @var int
+     */
+    public $amount;
+
+    /**
+     * @var string value of Currency
+     */
+    public $currency;
+}

--- a/lib/Checkout/Issuing/Testing/TransactionType.php
+++ b/lib/Checkout/Issuing/Testing/TransactionType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Checkout\Issuing\Testing;
+
+class TransactionType
+{
+    public static $purchase = "purchase";
+}

--- a/test/Checkout/Tests/Issuing/AbstractIssuingIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/AbstractIssuingIntegrationTest.php
@@ -16,6 +16,10 @@ use Checkout\Issuing\Cardholders\CardholderType;
 use Checkout\Issuing\Cards\Create\CardLifetime;
 use Checkout\Issuing\Cards\Create\LifetimeUnit;
 use Checkout\Issuing\Cards\Create\VirtualCardRequest;
+use Checkout\Issuing\Controls\Create\VelocityCardControlRequest;
+use Checkout\Issuing\Controls\VelocityLimit;
+use Checkout\Issuing\Controls\VelocityWindow;
+use Checkout\Issuing\Controls\VelocityWindowType;
 use Checkout\OAuthScope;
 use Checkout\PlatformType;
 use Checkout\Tests\SandboxTestFixture;
@@ -120,5 +124,30 @@ abstract class AbstractIssuingIntegrationTest extends SandboxTestFixture
 
         $this->assertResponse($cardResponse, "id");
         return $cardResponse;
+    }
+
+    /**
+     * @param $cardId string
+     * @return mixed
+     * @throws CheckoutApiException
+     */
+    protected function createCardControl($cardId)
+    {
+        $windowType = new VelocityWindow();
+        $windowType->type = VelocityWindowType::$weekly;
+
+        $velocityLimit = new VelocityLimit();
+        $velocityLimit->amount_limit = 500;
+        $velocityLimit->velocity_window = $windowType;
+
+        $controlRequest = new VelocityCardControlRequest();
+        $controlRequest->description = "Max spend of 500€ per week for restaurants";
+        $controlRequest->target_id = $cardId;
+        $controlRequest->velocity_limit = $velocityLimit;
+
+        $controlResponse = $this->issuingApi->getIssuingClient()->createControl($controlRequest);
+
+        $this->assertResponse($controlResponse, "id");
+        return $controlResponse;
     }
 }

--- a/test/Checkout/Tests/Issuing/AbstractIssuingIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/AbstractIssuingIntegrationTest.php
@@ -150,4 +150,12 @@ abstract class AbstractIssuingIntegrationTest extends SandboxTestFixture
         $this->assertResponse($controlResponse, "id");
         return $controlResponse;
     }
+
+    /**
+     * @return string
+     */
+    protected function getPassword()
+    {
+        return "Xtui43FvfiZ";
+    }
 }

--- a/test/Checkout/Tests/Issuing/AbstractIssuingIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/AbstractIssuingIntegrationTest.php
@@ -13,6 +13,9 @@ use Checkout\Environment;
 use Checkout\Issuing\Cardholders\CardholderDocument;
 use Checkout\Issuing\Cardholders\CardholderRequest;
 use Checkout\Issuing\Cardholders\CardholderType;
+use Checkout\Issuing\Cards\Create\CardLifetime;
+use Checkout\Issuing\Cards\Create\LifetimeUnit;
+use Checkout\Issuing\Cards\Create\VirtualCardRequest;
 use Checkout\OAuthScope;
 use Checkout\PlatformType;
 use Checkout\Tests\SandboxTestFixture;
@@ -90,5 +93,32 @@ abstract class AbstractIssuingIntegrationTest extends SandboxTestFixture
 
         $this->assertResponse($cardholderResponse, "id");
         return $cardholderResponse;
+    }
+
+    /**
+     * @param $cardholderId string
+     * @param $activate boolean
+     * @return mixed
+     * @throws CheckoutApiException
+     */
+    protected function createCard($cardholderId, $activate = false)
+    {
+        $lifetime = new CardLifetime();
+        $lifetime->unit = LifetimeUnit::$months;
+        $lifetime->value = 6;
+
+        $cardRequest = new VirtualCardRequest();
+        $cardRequest->cardholder_id = $cardholderId;
+        $cardRequest->card_product_id = "pro_3fn6pv2ikshurn36dbd3iysyha";
+        $cardRequest->lifetime = $lifetime;
+        $cardRequest->reference = "X-123456-N11";
+        $cardRequest->display_name = "John Kennedy";
+        $cardRequest->is_single_use = false;
+        $cardRequest->activate_card = $activate;
+
+        $cardResponse = $this->issuingApi->getIssuingClient()->createCard($cardRequest);
+
+        $this->assertResponse($cardResponse, "id");
+        return $cardResponse;
     }
 }

--- a/test/Checkout/Tests/Issuing/IssuingCardsIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingCardsIntegrationTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Checkout\Tests\Issuing;
+
+use Checkout\CheckoutApiException;
+use Checkout\CheckoutArgumentException;
+use Checkout\CheckoutAuthorizationException;
+use Checkout\CheckoutException;
+use Checkout\Issuing\Cards\Credentials\CardCredentialsQuery;
+use Checkout\Issuing\Cards\Enrollment\PasswordThreeDSEnrollmentRequest;
+use Checkout\Issuing\Cards\Enrollment\SecurityPair;
+use Checkout\Issuing\Cards\Enrollment\UpdateThreeDSEnrollmentRequest;
+use Checkout\Issuing\Cards\Revoke\RevokeCardRequest;
+use Checkout\Issuing\Cards\Revoke\RevokeReason;
+use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
+use Checkout\Issuing\Cards\Suspend\SuspendReason;
+
+class IssuingCardsIntegrationTest extends AbstractIssuingIntegrationTest
+{
+    private $cardholder;
+    private $card;
+
+    /**
+     * @before
+     * @throws CheckoutAuthorizationException
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
+    public function beforeAll()
+    {
+        $this->markTestSkipped("Avoid creating cards all the time");
+
+        $this->before();
+        $this->cardholder = $this->createCardholder();
+        $this->card = $this->createCard($this->cardholder["id"]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateCard()
+    {
+        $card = $this->card;
+
+        $this->assertResponse(
+            $card,
+            "id",
+            "display_name",
+            "last_four",
+            "expiry_month",
+            "expiry_year",
+            "billing_currency",
+            "issuing_country",
+            "reference"
+        );
+        $this->assertEquals("JOHN KENNEDY", $card["display_name"]);
+        $this->assertEquals("X-123456-N11", $card["reference"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardDetails()
+    {
+        $cardResponse = $this->issuingApi->getIssuingClient()->getCardDetails($this->card["id"]);
+
+        $this->assertResponse(
+            $cardResponse,
+            "id",
+            "cardholder_id",
+            "card_product_id",
+            "display_name",
+            "last_four",
+            "expiry_month",
+            "expiry_year",
+            "billing_currency",
+            "issuing_country",
+            "reference",
+            "status",
+            "type"
+        );
+        $this->assertEquals($this->card["id"], $cardResponse["id"]);
+        $this->assertEquals($this->cardholder["id"], $cardResponse["cardholder_id"]);
+        $this->assertEquals("pro_3fn6pv2ikshurn36dbd3iysyha", $cardResponse["card_product_id"]);
+        $this->assertEquals("X-123456-N11", $cardResponse["reference"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldEnrollCardIntoThreeDS()
+    {
+        $enrollRequest = new PasswordThreeDSEnrollmentRequest();
+        $enrollRequest->password = "Xtui43FvfiZ";
+        $enrollRequest->locale = "en-US";
+        $enrollRequest->phone_number = $this->getPhone();
+
+        $enrollmentResponse = $this->issuingApi->getIssuingClient()->enrollThreeDS($this->card["id"], $enrollRequest);
+
+        $this->assertEquals(202, $enrollmentResponse["http_metadata"]->getStatusCode());
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldUpdateThreeDSEnrollment()
+    {
+        $securityPair = new SecurityPair();
+        $securityPair->question = "Who are you?";
+        $securityPair->answer = "Bond. James Bond.";
+
+        $enrollRequest = new UpdateThreeDSEnrollmentRequest();
+        $enrollRequest->password = "Xtui43FvfiZ";
+        $enrollRequest->security_pair = $securityPair;
+        $enrollRequest->locale = "en-US";
+        $enrollRequest->phone_number = $this->getPhone();
+
+        $updateResponse = $this->issuingApi->getIssuingClient()->updateThreeDSEnrollment(
+            $this->card["id"],
+            $enrollRequest
+        );
+
+        $this->assertEquals(202, $updateResponse["http_metadata"]->getStatusCode());
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetThreeDSDetails()
+    {
+        $threeDSResponse = $this->issuingApi->getIssuingClient()->getCardThreeDSDetails($this->card["id"]);
+
+        $this->assertResponse(
+            $threeDSResponse,
+            "locale",
+            "phone_number"
+        );
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldActivateCard()
+    {
+        $activateResponse = $this->issuingApi->getIssuingClient()->activateCard($this->card["id"]);
+
+        $this->assertEquals(200, $activateResponse["http_metadata"]->getStatusCode());
+
+        $cardResponse = $this->issuingApi->getIssuingClient()->getCardDetails($this->card["id"]);
+
+        $this->assertEquals("active", $cardResponse["status"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardCredentials()
+    {
+        $queryRequest = new CardCredentialsQuery();
+        $queryRequest->credentials = "number, cvc2";
+
+        $queryResponse = $this->issuingApi->getIssuingClient()->getCardCredentials($this->card["id"], $queryRequest);
+
+        $this->assertResponse(
+            $queryResponse,
+            "number",
+            "cvc2"
+        );
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldRevokeCard()
+    {
+        $card = $this->createCard($this->cardholder["id"], true);
+
+        $revokeRequest = new RevokeCardRequest();
+        $revokeRequest->reason = RevokeReason::$reported_stolen;
+
+        $revokeResponse = $this->issuingApi->getIssuingClient()->revokeCard($card["id"], $revokeRequest);
+
+        $this->assertEquals(200, $revokeResponse["http_metadata"]->getStatusCode());
+
+        $cardResponse = $this->issuingApi->getIssuingClient()->getCardDetails($card["id"]);
+
+        $this->assertEquals("revoked", $cardResponse["status"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldSuspendCard()
+    {
+        $card = $this->createCard($this->cardholder["id"], true);
+
+        $suspendRequest = new SuspendCardRequest();
+        $suspendRequest->reason = SuspendReason::$suspected_stolen;
+
+        $suspendResponse = $this->issuingApi->getIssuingClient()->suspendCard($card["id"], $suspendRequest);
+
+        $this->assertEquals(200, $suspendResponse["http_metadata"]->getStatusCode());
+
+        $cardResponse = $this->issuingApi->getIssuingClient()->getCardDetails($card["id"]);
+
+        $this->assertEquals("suspended", $cardResponse["status"]);
+    }
+}

--- a/test/Checkout/Tests/Issuing/IssuingCardsIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingCardsIntegrationTest.php
@@ -93,7 +93,7 @@ class IssuingCardsIntegrationTest extends AbstractIssuingIntegrationTest
     public function shouldEnrollCardIntoThreeDS()
     {
         $enrollRequest = new PasswordThreeDSEnrollmentRequest();
-        $enrollRequest->password = "Xtui43FvfiZ";
+        $enrollRequest->password = $this->getPassword();
         $enrollRequest->locale = "en-US";
         $enrollRequest->phone_number = $this->getPhone();
 
@@ -113,7 +113,7 @@ class IssuingCardsIntegrationTest extends AbstractIssuingIntegrationTest
         $securityPair->answer = "Bond. James Bond.";
 
         $enrollRequest = new UpdateThreeDSEnrollmentRequest();
-        $enrollRequest->password = "Xtui43FvfiZ";
+        $enrollRequest->password = $this->getPassword();
         $enrollRequest->security_pair = $securityPair;
         $enrollRequest->locale = "en-US";
         $enrollRequest->phone_number = $this->getPhone();

--- a/test/Checkout/Tests/Issuing/IssuingClientTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingClientTest.php
@@ -2,12 +2,17 @@
 
 namespace Checkout\Tests\Issuing;
 
-use Checkout\AuthorizationType;
 use Checkout\CheckoutApiException;
 use Checkout\CheckoutArgumentException;
 use Checkout\CheckoutAuthorizationException;
 use Checkout\CheckoutException;
 use Checkout\Issuing\Cardholders\CardholderRequest;
+use Checkout\Issuing\Cards\Create\PhysicalCardRequest;
+use Checkout\Issuing\Cards\Credentials\CardCredentialsQuery;
+use Checkout\Issuing\Cards\Enrollment\PasswordThreeDSEnrollmentRequest;
+use Checkout\Issuing\Cards\Enrollment\UpdateThreeDSEnrollmentRequest;
+use Checkout\Issuing\Cards\Revoke\RevokeCardRequest;
+use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
 use Checkout\Issuing\IssuingClient;
 use Checkout\PlatformType;
 use Checkout\Tests\UnitTestFixture;
@@ -73,6 +78,141 @@ class IssuingClientTest extends UnitTestFixture
             ->willReturn("foo");
 
         $response = $this->client->getCardholderCards("cardholder_id");
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCreateCard()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->createCard(new PhysicalCardRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardDetails()
+    {
+
+        $this->apiClient
+            ->method("get")
+            ->willReturn("foo");
+
+        $response = $this->client->getCardDetails("card_id");
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldEnrollThreeDS()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->enrollThreeDS("card_id", new PasswordThreeDSEnrollmentRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldUpdateThreeDSEnrollment()
+    {
+
+        $this->apiClient
+            ->method("patch")
+            ->willReturn("foo");
+
+        $response = $this->client->updateThreeDSEnrollment("card_id", new UpdateThreeDSEnrollmentRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardThreeDSDetails()
+    {
+
+        $this->apiClient
+            ->method("get")
+            ->willReturn("foo");
+
+        $response = $this->client->getCardThreeDSDetails("card_id");
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldActivateCard()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->activateCard("card_id");
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardCredentials()
+    {
+
+        $this->apiClient
+            ->method("query")
+            ->willReturn("foo");
+
+        $response = $this->client->getCardCredentials("card_id", new CardCredentialsQuery());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldRevokeCard()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->revokeCard("card_id", new RevokeCardRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldSuspendCard()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->suspendCard("card_id", new SuspendCardRequest());
         $this->assertNotNull($response);
     }
 }

--- a/test/Checkout/Tests/Issuing/IssuingClientTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingClientTest.php
@@ -13,6 +13,9 @@ use Checkout\Issuing\Cards\Enrollment\PasswordThreeDSEnrollmentRequest;
 use Checkout\Issuing\Cards\Enrollment\UpdateThreeDSEnrollmentRequest;
 use Checkout\Issuing\Cards\Revoke\RevokeCardRequest;
 use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
+use Checkout\Issuing\Controls\Create\VelocityCardControlRequest;
+use Checkout\Issuing\Controls\Query\CardControlsQuery;
+use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
 use Checkout\Issuing\IssuingClient;
 use Checkout\PlatformType;
 use Checkout\Tests\UnitTestFixture;
@@ -213,6 +216,81 @@ class IssuingClientTest extends UnitTestFixture
             ->willReturn("foo");
 
         $response = $this->client->suspendCard("card_id", new SuspendCardRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCreateControl()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->createControl(new VelocityCardControlRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardControls()
+    {
+
+        $this->apiClient
+            ->method("query")
+            ->willReturn("foo");
+
+        $response = $this->client->getCardControls(new CardControlsQuery());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetControlDetails()
+    {
+
+        $this->apiClient
+            ->method("get")
+            ->willReturn("foo");
+
+        $response = $this->client->getCardControlDetails("control_id");
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldUpdateCardControl()
+    {
+
+        $this->apiClient
+            ->method("put")
+            ->willReturn("foo");
+
+        $response = $this->client->updateCardControl("control_id", new UpdateCardControlRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldRemoveControl()
+    {
+
+        $this->apiClient
+            ->method("delete")
+            ->willReturn("foo");
+
+        $response = $this->client->removeCardControl("control_id");
         $this->assertNotNull($response);
     }
 }

--- a/test/Checkout/Tests/Issuing/IssuingClientTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingClientTest.php
@@ -17,6 +17,7 @@ use Checkout\Issuing\Controls\Create\VelocityCardControlRequest;
 use Checkout\Issuing\Controls\Query\CardControlsQuery;
 use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
 use Checkout\Issuing\IssuingClient;
+use Checkout\Issuing\Testing\CardAuthorizationRequest;
 use Checkout\PlatformType;
 use Checkout\Tests\UnitTestFixture;
 
@@ -291,6 +292,21 @@ class IssuingClientTest extends UnitTestFixture
             ->willReturn("foo");
 
         $response = $this->client->removeCardControl("control_id");
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldSimulateAuthorization()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->simulateAuthorization(new CardAuthorizationRequest());
         $this->assertNotNull($response);
     }
 }

--- a/test/Checkout/Tests/Issuing/IssuingControlsIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingControlsIntegrationTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Checkout\Tests\Issuing;
+
+use Checkout\CheckoutApiException;
+use Checkout\CheckoutArgumentException;
+use Checkout\CheckoutAuthorizationException;
+use Checkout\CheckoutException;
+use Checkout\Issuing\Controls\ControlType;
+use Checkout\Issuing\Controls\Query\CardControlsQuery;
+use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
+use Checkout\Issuing\Controls\VelocityLimit;
+use Checkout\Issuing\Controls\VelocityWindow;
+use Checkout\Issuing\Controls\VelocityWindowType;
+
+class IssuingControlsIntegrationTest extends AbstractIssuingIntegrationTest
+{
+    private $cardholder;
+    private $card;
+    private $control;
+
+    /**
+     * @before
+     * @throws CheckoutAuthorizationException
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
+    public function beforeAll()
+    {
+        $this->markTestSkipped("Avoid creating cards all the time");
+
+        $this->before();
+        $this->cardholder = $this->createCardholder();
+        $this->card = $this->createCard($this->cardholder["id"], true);
+        $this->control = $this->createCardControl($this->card["id"]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateControl()
+    {
+        $control = $this->control;
+
+        $this->assertResponse(
+            $control,
+            "id",
+            "description",
+            "control_type",
+            "target_id"
+        );
+        $this->assertEquals($this->card["id"], $control["target_id"]);
+        $this->assertEquals(ControlType::$velocity_limit, $control["control_type"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardControls()
+    {
+        $query = new CardControlsQuery();
+        $query->target_id = $this->card["id"];
+
+        $controls = $this->issuingApi->getIssuingClient()->getCardControls($query);
+
+        $this->assertResponse(
+            $controls,
+            "controls"
+        );
+        foreach ($controls["controls"] as $control) {
+            $this->assertEquals($this->card["id"], $control["target_id"]);
+        }
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetControlDetails()
+    {
+        $control = $this->issuingApi->getIssuingClient()->getCardControlDetails($this->control["id"]);
+
+        $this->assertResponse(
+            $control,
+            "id",
+            "description",
+            "control_type",
+            "target_id"
+        );
+        $this->assertEquals($this->control["id"], $control["id"]);
+        $this->assertEquals($this->card["id"], $control["target_id"]);
+        $this->assertEquals(ControlType::$velocity_limit, $control["control_type"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldUpdateControl()
+    {
+        $windowType = new VelocityWindow();
+        $windowType->type = VelocityWindowType::$monthly;
+
+        $velocityLimit = new VelocityLimit();
+        $velocityLimit->amount_limit = 1000;
+        $velocityLimit->velocity_window = $windowType;
+
+        $updateRequest = new UpdateCardControlRequest();
+        $updateRequest->description = "New max spend of 1000€ per month for restaurants";
+        $updateRequest->velocity_limit = $velocityLimit;
+
+        $control = $this->issuingApi->getIssuingClient()->updateCardControl($this->control["id"], $updateRequest);
+
+        $this->assertResponse(
+            $control,
+            "id",
+            "description",
+            "control_type",
+            "target_id"
+        );
+        $this->assertEquals($this->control["id"], $control["id"]);
+        $this->assertEquals($this->card["id"], $control["target_id"]);
+        $this->assertEquals(ControlType::$velocity_limit, $control["control_type"]);
+        $this->assertEquals("New max spend of 1000€ per month for restaurants", $control["description"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldRemoveControl()
+    {
+        $control = $this->issuingApi->getIssuingClient()->removeCardControl($this->control["id"]);
+
+        $this->assertResponse(
+            $control,
+            "id"
+        );
+        $this->assertEquals($this->control["id"], $control["id"]);
+    }
+}

--- a/test/Checkout/Tests/Issuing/IssuingTestingIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingTestingIntegrationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Checkout\Tests\Issuing;
+
+use Checkout\CheckoutApiException;
+use Checkout\CheckoutArgumentException;
+use Checkout\CheckoutAuthorizationException;
+use Checkout\CheckoutException;
+use Checkout\Common\Currency;
+use Checkout\Issuing\Testing\CardAuthorizationRequest;
+use Checkout\Issuing\Testing\CardSimulation;
+use Checkout\Issuing\Testing\TransactionSimulation;
+use Checkout\Issuing\Testing\TransactionType;
+
+class IssuingTestingIntegrationTest extends AbstractIssuingIntegrationTest
+{
+    private $cardholder;
+    private $card;
+
+    /**
+     * @before
+     * @throws CheckoutAuthorizationException
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
+    public function beforeAll()
+    {
+        $this->markTestSkipped("Avoid creating cards all the time");
+
+        $this->before();
+        $this->cardholder = $this->createCardholder();
+        $this->card = $this->createCard($this->cardholder["id"], true);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldSimulateAuthorization()
+    {
+        $cardSimulation = new CardSimulation();
+        $cardSimulation->id = $this->card["id"];
+        $cardSimulation->expiry_month = $this->card["expiry_month"];
+        $cardSimulation->expiry_year = $this->card["expiry_year"];
+
+        $transactionSimulation = new TransactionSimulation();
+        $transactionSimulation->type = TransactionType::$purchase;
+        $transactionSimulation->amount = 100;
+        $transactionSimulation->currency = Currency::$GBP;
+
+        $authorizationRequest = new CardAuthorizationRequest();
+        $authorizationRequest->card = $cardSimulation;
+        $authorizationRequest->transaction = $transactionSimulation;
+
+        $simulationResponse = $this->issuingApi->getIssuingClient()->simulateAuthorization($authorizationRequest);
+
+        $this->assertResponse(
+            $simulationResponse,
+            "id",
+            "status"
+        );
+        $this->assertEquals("Authorized", $simulationResponse["status"]);
+    }
+}


### PR DESCRIPTION
### Changes
* Adds support for `createCard`
* Adds support for `getCardDetails`
* Adds support for `enrollThreeDS`
* Adds support for `updateThreeDSEnrollment`
* Adds support for `getCardThreeDSDetails`
* Adds support for `activateCard`
* Adds support for `getCardCredentials`
* Adds support for `revokeCard`
* Adds support for `suspendCard`

### Related PRs
#207 

### API Reference
https://api-reference.checkout.com/#tag/Cards