### PR TITLE
Adds support for Card Control operations [Issuing] (CS2)

### DIFF
--- a/lib/Checkout/Issuing/Controls/ControlType.php
+++ b/lib/Checkout/Issuing/Controls/ControlType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class ControlType
+{
+    public static $velocity_limit = "velocity_limit";
+    public static $mcc_limit = "mcc_limit";
+}

--- a/lib/Checkout/Issuing/Controls/Create/CardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Create/CardControlRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Create;
+
+abstract class CardControlRequest
+{
+    public function __construct($type)
+    {
+        $this->control_type = $type;
+    }
+
+    /**
+     * @var string value of ControlType
+     */
+    public $control_type;
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var string
+     */
+    public $target_id;
+}

--- a/lib/Checkout/Issuing/Controls/Create/MccCardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Create/MccCardControlRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Create;
+
+use Checkout\Issuing\Controls\ControlType;
+use Checkout\Issuing\Controls\MccLimit;
+
+class MccCardControlRequest extends CardControlRequest
+{
+    public function __construct()
+    {
+        parent::__construct(ControlType::$mcc_limit);
+    }
+
+    /**
+     * @var MccLimit
+     */
+    public $mcc_limit;
+}

--- a/lib/Checkout/Issuing/Controls/Create/VelocityCardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Create/VelocityCardControlRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Create;
+
+use Checkout\Issuing\Controls\ControlType;
+use Checkout\Issuing\Controls\VelocityLimit;
+
+class VelocityCardControlRequest extends CardControlRequest
+{
+    public function __construct()
+    {
+        parent::__construct(ControlType::$velocity_limit);
+    }
+
+    /**
+     * @var VelocityLimit
+     */
+    public $velocity_limit;
+}

--- a/lib/Checkout/Issuing/Controls/MccControlType.php
+++ b/lib/Checkout/Issuing/Controls/MccControlType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class MccControlType
+{
+    public static $allow = "allow";
+    public static $block = "block";
+}

--- a/lib/Checkout/Issuing/Controls/MccLimit.php
+++ b/lib/Checkout/Issuing/Controls/MccLimit.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class MccLimit
+{
+    /**
+     * @var string value of MccControlType
+     */
+    public $type;
+
+    /**
+     * @var array of string
+     */
+    public $mcc_list;
+}

--- a/lib/Checkout/Issuing/Controls/Query/CardControlsQuery.php
+++ b/lib/Checkout/Issuing/Controls/Query/CardControlsQuery.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Query;
+
+use Checkout\Common\AbstractQueryFilter;
+
+class CardControlsQuery extends AbstractQueryFilter
+{
+    /**
+     * @var string
+     */
+    public $target_id;
+}

--- a/lib/Checkout/Issuing/Controls/Update/UpdateCardControlRequest.php
+++ b/lib/Checkout/Issuing/Controls/Update/UpdateCardControlRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Checkout\Issuing\Controls\Update;
+
+use Checkout\Issuing\Controls\MccLimit;
+use Checkout\Issuing\Controls\VelocityLimit;
+
+class UpdateCardControlRequest
+{
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var VelocityLimit
+     */
+    public $velocity_limit;
+
+    /**
+     * @var MccLimit
+     */
+    public $mcc_limit;
+}

--- a/lib/Checkout/Issuing/Controls/VelocityLimit.php
+++ b/lib/Checkout/Issuing/Controls/VelocityLimit.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class VelocityLimit
+{
+    /**
+     * @var int
+     */
+    public $amount_limit;
+
+    /**
+     * @var VelocityWindow
+     */
+    public $velocity_window;
+
+    /**
+     * @var array of string
+     */
+    public $mcc_list;
+}

--- a/lib/Checkout/Issuing/Controls/VelocityWindow.php
+++ b/lib/Checkout/Issuing/Controls/VelocityWindow.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class VelocityWindow
+{
+    /**
+     * @var string value of VelocityWindowType
+     */
+    public $type;
+}

--- a/lib/Checkout/Issuing/Controls/VelocityWindowType.php
+++ b/lib/Checkout/Issuing/Controls/VelocityWindowType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Issuing\Controls;
+
+class VelocityWindowType
+{
+    public static $daily = "daily";
+    public static $weekly = "weekly";
+    public static $monthly = "monthly";
+    public static $all_time = "all_time";
+}

--- a/lib/Checkout/Issuing/IssuingClient.php
+++ b/lib/Checkout/Issuing/IssuingClient.php
@@ -14,6 +14,9 @@ use Checkout\Issuing\Cards\Enrollment\ThreeDSEnrollmentRequest;
 use Checkout\Issuing\Cards\Enrollment\UpdateThreeDSEnrollmentRequest;
 use Checkout\Issuing\Cards\Revoke\RevokeCardRequest;
 use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
+use Checkout\Issuing\Controls\Create\CardControlRequest;
+use Checkout\Issuing\Controls\Query\CardControlsQuery;
+use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
 
 class IssuingClient extends Client
 {
@@ -25,6 +28,7 @@ class IssuingClient extends Client
     const CREDENTIALS_PATH = "credentials";
     const REVOKE_PATH = "revoke";
     const SUSPEND_PATH = "suspend";
+    const CONTROLS_PATH = "controls";
 
     public function __construct(ApiClient $apiClient, CheckoutConfiguration $configuration)
     {
@@ -196,6 +200,75 @@ class IssuingClient extends Client
         return $this->apiClient->post(
             $this->buildPath(self::ISSUING_PATH, self::CARDS_PATH, $cardId, self::SUSPEND_PATH),
             $suspendCardRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param CardControlRequest $cardControlRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function createControl(CardControlRequest $cardControlRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH),
+            $cardControlRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param CardControlsQuery $query
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getCardControls(CardControlsQuery $query)
+    {
+        return $this->apiClient->query(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH),
+            $query,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param $controlId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getCardControlDetails($controlId)
+    {
+        return $this->apiClient->get(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH, $controlId),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param string $controlId
+     * @param UpdateCardControlRequest $updateCardControlRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function updateCardControl($controlId, UpdateCardControlRequest $updateCardControlRequest)
+    {
+        return $this->apiClient->put(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH, $controlId),
+            $updateCardControlRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param $controlId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function removeCardControl($controlId)
+    {
+        return $this->apiClient->delete(
+            $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH, $controlId),
             $this->sdkAuthorization()
         );
     }

--- a/test/Checkout/Tests/Issuing/AbstractIssuingIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/AbstractIssuingIntegrationTest.php
@@ -16,6 +16,10 @@ use Checkout\Issuing\Cardholders\CardholderType;
 use Checkout\Issuing\Cards\Create\CardLifetime;
 use Checkout\Issuing\Cards\Create\LifetimeUnit;
 use Checkout\Issuing\Cards\Create\VirtualCardRequest;
+use Checkout\Issuing\Controls\Create\VelocityCardControlRequest;
+use Checkout\Issuing\Controls\VelocityLimit;
+use Checkout\Issuing\Controls\VelocityWindow;
+use Checkout\Issuing\Controls\VelocityWindowType;
 use Checkout\OAuthScope;
 use Checkout\PlatformType;
 use Checkout\Tests\SandboxTestFixture;
@@ -120,5 +124,30 @@ abstract class AbstractIssuingIntegrationTest extends SandboxTestFixture
 
         $this->assertResponse($cardResponse, "id");
         return $cardResponse;
+    }
+
+    /**
+     * @param $cardId string
+     * @return mixed
+     * @throws CheckoutApiException
+     */
+    protected function createCardControl($cardId)
+    {
+        $windowType = new VelocityWindow();
+        $windowType->type = VelocityWindowType::$weekly;
+
+        $velocityLimit = new VelocityLimit();
+        $velocityLimit->amount_limit = 500;
+        $velocityLimit->velocity_window = $windowType;
+
+        $controlRequest = new VelocityCardControlRequest();
+        $controlRequest->description = "Max spend of 500€ per week for restaurants";
+        $controlRequest->target_id = $cardId;
+        $controlRequest->velocity_limit = $velocityLimit;
+
+        $controlResponse = $this->issuingApi->getIssuingClient()->createControl($controlRequest);
+
+        $this->assertResponse($controlResponse, "id");
+        return $controlResponse;
     }
 }

--- a/test/Checkout/Tests/Issuing/IssuingClientTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingClientTest.php
@@ -13,6 +13,9 @@ use Checkout\Issuing\Cards\Enrollment\PasswordThreeDSEnrollmentRequest;
 use Checkout\Issuing\Cards\Enrollment\UpdateThreeDSEnrollmentRequest;
 use Checkout\Issuing\Cards\Revoke\RevokeCardRequest;
 use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
+use Checkout\Issuing\Controls\Create\VelocityCardControlRequest;
+use Checkout\Issuing\Controls\Query\CardControlsQuery;
+use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
 use Checkout\Issuing\IssuingClient;
 use Checkout\PlatformType;
 use Checkout\Tests\UnitTestFixture;
@@ -213,6 +216,81 @@ class IssuingClientTest extends UnitTestFixture
             ->willReturn("foo");
 
         $response = $this->client->suspendCard("card_id", new SuspendCardRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCreateControl()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->createControl(new VelocityCardControlRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardControls()
+    {
+
+        $this->apiClient
+            ->method("query")
+            ->willReturn("foo");
+
+        $response = $this->client->getCardControls(new CardControlsQuery());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetControlDetails()
+    {
+
+        $this->apiClient
+            ->method("get")
+            ->willReturn("foo");
+
+        $response = $this->client->getCardControlDetails("control_id");
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldUpdateCardControl()
+    {
+
+        $this->apiClient
+            ->method("put")
+            ->willReturn("foo");
+
+        $response = $this->client->updateCardControl("control_id", new UpdateCardControlRequest());
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldRemoveControl()
+    {
+
+        $this->apiClient
+            ->method("delete")
+            ->willReturn("foo");
+
+        $response = $this->client->removeCardControl("control_id");
         $this->assertNotNull($response);
     }
 }

--- a/test/Checkout/Tests/Issuing/IssuingControlsIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingControlsIntegrationTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Checkout\Tests\Issuing;
+
+use Checkout\CheckoutApiException;
+use Checkout\CheckoutArgumentException;
+use Checkout\CheckoutAuthorizationException;
+use Checkout\CheckoutException;
+use Checkout\Issuing\Controls\ControlType;
+use Checkout\Issuing\Controls\Query\CardControlsQuery;
+use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
+use Checkout\Issuing\Controls\VelocityLimit;
+use Checkout\Issuing\Controls\VelocityWindow;
+use Checkout\Issuing\Controls\VelocityWindowType;
+
+class IssuingControlsIntegrationTest extends AbstractIssuingIntegrationTest
+{
+    private $cardholder;
+    private $card;
+    private $control;
+
+    /**
+     * @before
+     * @throws CheckoutAuthorizationException
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
+    public function beforeAll()
+    {
+        $this->markTestSkipped("Avoid creating cards all the time");
+
+        $this->before();
+        $this->cardholder = $this->createCardholder();
+        $this->card = $this->createCard($this->cardholder["id"], true);
+        $this->control = $this->createCardControl($this->card["id"]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateControl()
+    {
+        $control = $this->control;
+
+        $this->assertResponse(
+            $control,
+            "id",
+            "description",
+            "control_type",
+            "target_id"
+        );
+        $this->assertEquals($this->card["id"], $control["target_id"]);
+        $this->assertEquals(ControlType::$velocity_limit, $control["control_type"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetCardControls()
+    {
+        $query = new CardControlsQuery();
+        $query->target_id = $this->card["id"];
+
+        $controls = $this->issuingApi->getIssuingClient()->getCardControls($query);
+
+        $this->assertResponse(
+            $controls,
+            "controls"
+        );
+        foreach ($controls["controls"] as $control) {
+            $this->assertEquals($this->card["id"], $control["target_id"]);
+        }
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetControlDetails()
+    {
+        $control = $this->issuingApi->getIssuingClient()->getCardControlDetails($this->control["id"]);
+
+        $this->assertResponse(
+            $control,
+            "id",
+            "description",
+            "control_type",
+            "target_id"
+        );
+        $this->assertEquals($this->control["id"], $control["id"]);
+        $this->assertEquals($this->card["id"], $control["target_id"]);
+        $this->assertEquals(ControlType::$velocity_limit, $control["control_type"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldUpdateControl()
+    {
+        $windowType = new VelocityWindow();
+        $windowType->type = VelocityWindowType::$monthly;
+
+        $velocityLimit = new VelocityLimit();
+        $velocityLimit->amount_limit = 1000;
+        $velocityLimit->velocity_window = $windowType;
+
+        $updateRequest = new UpdateCardControlRequest();
+        $updateRequest->description = "New max spend of 1000€ per month for restaurants";
+        $updateRequest->velocity_limit = $velocityLimit;
+
+        $control = $this->issuingApi->getIssuingClient()->updateCardControl($this->control["id"], $updateRequest);
+
+        $this->assertResponse(
+            $control,
+            "id",
+            "description",
+            "control_type",
+            "target_id"
+        );
+        $this->assertEquals($this->control["id"], $control["id"]);
+        $this->assertEquals($this->card["id"], $control["target_id"]);
+        $this->assertEquals(ControlType::$velocity_limit, $control["control_type"]);
+        $this->assertEquals("New max spend of 1000€ per month for restaurants", $control["description"]);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldRemoveControl()
+    {
+        $control = $this->issuingApi->getIssuingClient()->removeCardControl($this->control["id"]);
+
+        $this->assertResponse(
+            $control,
+            "id"
+        );
+        $this->assertEquals($this->control["id"], $control["id"]);
+    }
+}


### PR DESCRIPTION
### Changes
* Adds support for `createControl`
* Adds support for `getCardControls`
* Adds support for `getCardControlDetails`
* Adds support for `updateCardControl`
* Adds support for `removeCardControl`

### Related PRs
#208 

### API Reference
https://api-reference.checkout.com/#tag/Card-controls