### PR TITLE
Adds support for Testing operations [Issuing] (CS2)

### DIFF
--- a/lib/Checkout/Issuing/IssuingClient.php
+++ b/lib/Checkout/Issuing/IssuingClient.php
@@ -17,6 +17,7 @@ use Checkout\Issuing\Cards\Suspend\SuspendCardRequest;
 use Checkout\Issuing\Controls\Create\CardControlRequest;
 use Checkout\Issuing\Controls\Query\CardControlsQuery;
 use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
+use Checkout\Issuing\Testing\CardAuthorizationRequest;
 
 class IssuingClient extends Client
 {
@@ -29,6 +30,8 @@ class IssuingClient extends Client
     const REVOKE_PATH = "revoke";
     const SUSPEND_PATH = "suspend";
     const CONTROLS_PATH = "controls";
+    const SIMULATE_PATH = "simulate";
+    const AUTHORIZATIONS_PATH = "authorizations";
 
     public function __construct(ApiClient $apiClient, CheckoutConfiguration $configuration)
     {
@@ -269,6 +272,20 @@ class IssuingClient extends Client
     {
         return $this->apiClient->delete(
             $this->buildPath(self::ISSUING_PATH, self::CONTROLS_PATH, $controlId),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * @param CardAuthorizationRequest $authorizationRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function simulateAuthorization(CardAuthorizationRequest $authorizationRequest)
+    {
+        return $this->apiClient->post(
+            $this->buildPath(self::ISSUING_PATH, self::SIMULATE_PATH, self::AUTHORIZATIONS_PATH),
+            $authorizationRequest,
             $this->sdkAuthorization()
         );
     }

--- a/lib/Checkout/Issuing/Testing/CardAuthorizationRequest.php
+++ b/lib/Checkout/Issuing/Testing/CardAuthorizationRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Checkout\Issuing\Testing;
+
+class CardAuthorizationRequest
+{
+    /**
+     * @var CardSimulation
+     */
+    public $card;
+
+    /**
+     * @var TransactionSimulation
+     */
+    public $transaction;
+}

--- a/lib/Checkout/Issuing/Testing/CardSimulation.php
+++ b/lib/Checkout/Issuing/Testing/CardSimulation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Checkout\Issuing\Testing;
+
+class CardSimulation
+{
+    /**
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @var int
+     */
+    public $expiry_month;
+
+    /**
+     * @var int
+     */
+    public $expiry_year;
+}

--- a/lib/Checkout/Issuing/Testing/TransactionSimulation.php
+++ b/lib/Checkout/Issuing/Testing/TransactionSimulation.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Checkout\Issuing\Testing;
+
+use Checkout\Common\Currency;
+
+class TransactionSimulation
+{
+    /**
+     * @var string value of TransactionType
+     */
+    public $type;
+
+    /**
+     * @var int
+     */
+    public $amount;
+
+    /**
+     * @var string value of Currency
+     */
+    public $currency;
+}

--- a/lib/Checkout/Issuing/Testing/TransactionType.php
+++ b/lib/Checkout/Issuing/Testing/TransactionType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Checkout\Issuing\Testing;
+
+class TransactionType
+{
+    public static $purchase = "purchase";
+}

--- a/test/Checkout/Tests/Issuing/IssuingClientTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingClientTest.php
@@ -17,6 +17,7 @@ use Checkout\Issuing\Controls\Create\VelocityCardControlRequest;
 use Checkout\Issuing\Controls\Query\CardControlsQuery;
 use Checkout\Issuing\Controls\Update\UpdateCardControlRequest;
 use Checkout\Issuing\IssuingClient;
+use Checkout\Issuing\Testing\CardAuthorizationRequest;
 use Checkout\PlatformType;
 use Checkout\Tests\UnitTestFixture;
 
@@ -291,6 +292,21 @@ class IssuingClientTest extends UnitTestFixture
             ->willReturn("foo");
 
         $response = $this->client->removeCardControl("control_id");
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldSimulateAuthorization()
+    {
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn("foo");
+
+        $response = $this->client->simulateAuthorization(new CardAuthorizationRequest());
         $this->assertNotNull($response);
     }
 }

--- a/test/Checkout/Tests/Issuing/IssuingTestingIntegrationTest.php
+++ b/test/Checkout/Tests/Issuing/IssuingTestingIntegrationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Checkout\Tests\Issuing;
+
+use Checkout\CheckoutApiException;
+use Checkout\CheckoutArgumentException;
+use Checkout\CheckoutAuthorizationException;
+use Checkout\CheckoutException;
+use Checkout\Common\Currency;
+use Checkout\Issuing\Testing\CardAuthorizationRequest;
+use Checkout\Issuing\Testing\CardSimulation;
+use Checkout\Issuing\Testing\TransactionSimulation;
+use Checkout\Issuing\Testing\TransactionType;
+
+class IssuingTestingIntegrationTest extends AbstractIssuingIntegrationTest
+{
+    private $cardholder;
+    private $card;
+
+    /**
+     * @before
+     * @throws CheckoutAuthorizationException
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
+    public function beforeAll()
+    {
+        $this->markTestSkipped("Avoid creating cards all the time");
+
+        $this->before();
+        $this->cardholder = $this->createCardholder();
+        $this->card = $this->createCard($this->cardholder["id"], true);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldSimulateAuthorization()
+    {
+        $cardSimulation = new CardSimulation();
+        $cardSimulation->id = $this->card["id"];
+        $cardSimulation->expiry_month = $this->card["expiry_month"];
+        $cardSimulation->expiry_year = $this->card["expiry_year"];
+
+        $transactionSimulation = new TransactionSimulation();
+        $transactionSimulation->type = TransactionType::$purchase;
+        $transactionSimulation->amount = 100;
+        $transactionSimulation->currency = Currency::$GBP;
+
+        $authorizationRequest = new CardAuthorizationRequest();
+        $authorizationRequest->card = $cardSimulation;
+        $authorizationRequest->transaction = $transactionSimulation;
+
+        $simulationResponse = $this->issuingApi->getIssuingClient()->simulateAuthorization($authorizationRequest);
+
+        $this->assertResponse(
+            $simulationResponse,
+            "id",
+            "status"
+        );
+        $this->assertEquals("Authorized", $simulationResponse["status"]);
+    }
+}


### PR DESCRIPTION
### Changes
* Adds support for `simulateAuthorization`

### Related PRs
#209 

### API Reference
https://api-reference.checkout.com/#tag/Card-testing