### PR TITLE
Update PaymentInstruction. Missing property

### DIFF
--- a/lib/Checkout/Payments/Request/PaymentInstruction.php
+++ b/lib/Checkout/Payments/Request/PaymentInstruction.php
@@ -28,4 +28,9 @@ class PaymentInstruction
      * @var string
      */
     public $quote_id;
+
+    /**
+     * @var string
+     */
+    public $funds_transfer_type;
 }


### PR DESCRIPTION
- Adds `funds_transfer_type` in `instruction` inside `payments`