### PR TITLE
Add authentication for payment request

### DIFF
--- a/lib/Checkout/Payments/PreferredExperiences.php
+++ b/lib/Checkout/Payments/PreferredExperiences.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Checkout\Payments;
+
+class PreferredExperiences
+{
+    public static $googleSpa = "google_spa";
+    public static $threeDs = "3ds";
+}

--- a/lib/Checkout/Payments/Request/Authentication.php
+++ b/lib/Checkout/Payments/Request/Authentication.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Payments\Request;
+
+class Authentication
+{
+    /**
+     * @var string value of PreferredExperiences
+     */
+    public $preferred_experiences;
+}

--- a/lib/Checkout/Payments/Request/PaymentRequest.php
+++ b/lib/Checkout/Payments/Request/PaymentRequest.php
@@ -57,6 +57,11 @@ class PaymentRequest
     public $description;
 
     /**
+     * @var Authentication
+     */
+    public $authentication;
+
+    /**
      * @var string value of AuthorizationType
      */
     public $authorization_type;

--- a/test/Checkout/Tests/Payments/IncrementPaymentsAuthorizationsTest.php
+++ b/test/Checkout/Tests/Payments/IncrementPaymentsAuthorizationsTest.php
@@ -7,6 +7,8 @@ use Checkout\Common\Currency;
 use Checkout\Common\CustomerRequest;
 use Checkout\Payments\AuthorizationRequest;
 use Checkout\Payments\AuthorizationType;
+use Checkout\Payments\PreferredExperiences;
+use Checkout\Payments\Request\Authentication;
 use Checkout\Payments\Request\PartialAuthorization;
 use Checkout\Payments\Request\PaymentRequest;
 use Checkout\Payments\Request\Source\RequestCardSource;
@@ -106,6 +108,9 @@ class IncrementPaymentsAuthorizationsTest extends AbstractPaymentsIntegrationTes
         $partialAuthorization = new PartialAuthorization();
         $partialAuthorization->enabled = true;
 
+        $authentication = new Authentication();
+        $authentication->preferred_experiences = PreferredExperiences::$googleSpa;
+
         $paymentRequest = new PaymentRequest();
         $paymentRequest->source = $requestCardSource;
         $paymentRequest->capture = false;
@@ -113,6 +118,7 @@ class IncrementPaymentsAuthorizationsTest extends AbstractPaymentsIntegrationTes
         $paymentRequest->amount = 10;
         $paymentRequest->authorization_type = AuthorizationType::$estimated;
         $paymentRequest->partial_authorization = $partialAuthorization;
+        $paymentRequest->authentication = $authentication;
         $paymentRequest->currency = Currency::$EUR;
         $paymentRequest->customer = $customerRequest;
         $paymentRequest->sender = $paymentIndividualSender;


### PR DESCRIPTION
Added authentication parameter to align with documentation:
https://api-reference.checkout.com/#operation/requestAPaymentOrPayout!path=0/authentication/preferred_experiences&t=request