### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,8 +1,10 @@
 name: build-master
+
 on:
     push:
         branches:
             - master
+
 jobs:
     build:
         if: "!contains(github.event.commits[0].message, 'Release')"
@@ -11,42 +13,50 @@ jobs:
             max-parallel: 1
             fail-fast: false
             matrix:
-                os: [ ubuntu-latest, windows-latest ]
-                php-version: [ "8.1", "5.6" ]
+                os: [ubuntu-latest, windows-latest]
+                php-version: ["7.1", "8.4"]
+
         steps:
-            -   uses: actions/checkout@v2
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php-version }}
-                    extensions: fileinfo
-                    coverage: xdebug
-            -   name: Installed version
-                run: php -v
-            -   name: Remove PHPStan
-                if: ${{ matrix.php-version == '5.6' }}
-                run: composer remove --dev phpstan/phpstan
-            -   name: Composer validate
-                run: composer validate
-            -   name: Composer install
-                run: composer install
-            -   name: Run PHPStan
-                if: ${{ matrix.php-version != '5.6' }}
-                run: vendor/bin/phpstan analyse --no-progress
-            -   name: Run PHPUnit
-                env:
-                    CHECKOUT_PROCESSING_CHANNEL_ID: ${{ secrets.IT_CHECKOUT_PROCESSING_CHANNEL_ID }}
-                    CHECKOUT_PREVIOUS_SECRET_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_SECRET_KEY }}
-                    CHECKOUT_PREVIOUS_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_PUBLIC_KEY }}
-                    CHECKOUT_DEFAULT_SECRET_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_SECRET_KEY }}
-                    CHECKOUT_DEFAULT_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_PUBLIC_KEY }}
-                    CHECKOUT_DEFAULT_OAUTH_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET }}
-                    CHECKOUT_MERCHANT_SUBDOMAIN: ${{ secrets.IT_CHECKOUT_MERCHANT_SUBDOMAIN }}
-                run: vendor/bin/phpunit --verbose
+            - uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-version }}
+                  extensions: fileinfo
+                  coverage: xdebug
+
+            - name: Installed version
+              run: php -v
+
+            - name: Composer validate
+              run: composer validate
+
+            - name: Composer install (conditional)
+              run: |
+                  if [[ "${{ matrix.php-version }}" == "7.1" ]]; then
+                    composer install;
+                  else
+                    composer require guzzlehttp/guzzle:"^7.4" guzzlehttp/promises:"^2.0" phpunit/phpunit:"^9.5" --dev --with-all-dependencies;
+                  fi
+
+            - name: Run PHPStan
+              run: vendor/bin/phpstan analyse --no-progress
+
+            - name: Run PHPUnit
+              env:
+                  CHECKOUT_PROCESSING_CHANNEL_ID: ${{ secrets.IT_CHECKOUT_PROCESSING_CHANNEL_ID }}
+                  CHECKOUT_PREVIOUS_SECRET_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_SECRET_KEY }}
+                  CHECKOUT_PREVIOUS_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_PUBLIC_KEY }}
+                  CHECKOUT_DEFAULT_SECRET_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_SECRET_KEY }}
+                  CHECKOUT_DEFAULT_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_PUBLIC_KEY }}
+                  CHECKOUT_DEFAULT_OAUTH_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET }}
+                  CHECKOUT_MERCHANT_SUBDOMAIN: ${{ secrets.IT_CHECKOUT_MERCHANT_SUBDOMAIN }}
+              run: vendor/bin/phpunit --verbose

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -1,10 +1,12 @@
 name: build-pull-request
+
 on:
     pull_request:
         branches:
             - master
             - 'integration/**'
             - 'feature/**'
+
 jobs:
     build:
         runs-on: ${{ matrix.os }}
@@ -12,41 +14,47 @@ jobs:
             max-parallel: 1
             fail-fast: false
             matrix:
-                os: [ ubuntu-latest ]
-                php-version: [ "8.1", "5.6" ]
+                os: [ubuntu-latest]
+                php-version: ["7.1", "8.4"]
+
         steps:
-            -   uses: actions/checkout@v2
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php-version }}
-                    coverage: xdebug
-            -   name: Installed version
-                run: php -v
-            -   name: Remove PHPStan
-                if: ${{ matrix.php-version == '5.6' }}
-                run: composer remove --dev phpstan/phpstan
-            -   name: Composer validate
-                run: composer validate
-            -   name: Composer install
-                run: composer install
-            -   name: Run PHPStan
-                if: ${{ matrix.php-version != '5.6' }}
-                run: vendor/bin/phpstan analyse --no-progress
-            -   name: Run PHPUnit
-                env:
-                    CHECKOUT_PROCESSING_CHANNEL_ID: ${{ secrets.IT_CHECKOUT_PROCESSING_CHANNEL_ID }}
-                    CHECKOUT_PREVIOUS_SECRET_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_SECRET_KEY }}
-                    CHECKOUT_PREVIOUS_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_PUBLIC_KEY }}
-                    CHECKOUT_DEFAULT_SECRET_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_SECRET_KEY }}
-                    CHECKOUT_DEFAULT_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_PUBLIC_KEY }}
-                    CHECKOUT_DEFAULT_OAUTH_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET }}
-                    CHECKOUT_MERCHANT_SUBDOMAIN: ${{ secrets.IT_CHECKOUT_MERCHANT_SUBDOMAIN }}
-                run: vendor/bin/phpunit --verbose
+            - uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-version }}
+                  extensions: fileinfo
+                  coverage: xdebug
+
+            - name: Composer validate
+              run: composer validate
+
+            - name: Composer install (conditional)
+              run: |
+                  if [[ "${{ matrix.php-version }}" == "7.1" ]]; then
+                    composer install;
+                  else
+                    composer require guzzlehttp/guzzle:"^7.4" guzzlehttp/promises:"^2.0" phpunit/phpunit:"^9.5" --dev --with-all-dependencies;
+                  fi
+
+            - name: Run PHPStan
+              run: vendor/bin/phpstan analyse --no-progress
+
+            - name: Run PHPUnit
+              env:
+                  CHECKOUT_PROCESSING_CHANNEL_ID: ${{ secrets.IT_CHECKOUT_PROCESSING_CHANNEL_ID }}
+                  CHECKOUT_PREVIOUS_SECRET_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_SECRET_KEY }}
+                  CHECKOUT_PREVIOUS_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_PUBLIC_KEY }}
+                  CHECKOUT_DEFAULT_SECRET_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_SECRET_KEY }}
+                  CHECKOUT_DEFAULT_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_PUBLIC_KEY }}
+                  CHECKOUT_DEFAULT_OAUTH_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET }}
+                  CHECKOUT_MERCHANT_SUBDOMAIN: ${{ secrets.IT_CHECKOUT_MERCHANT_SUBDOMAIN }}
+              run: vendor/bin/phpunit --verbose

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,5 @@
 name: build-release
+
 on:
     push:
         branches:
@@ -9,53 +10,63 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+
         steps:
-            -   uses: actions/checkout@v2
-            -   name: Setup PHP 5.6
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: "5.6"
-                    coverage: none
-            -   name: Installed version
-                run: php -v
-            -   name: Remove PHPStan
-                run: composer remove --dev phpstan/phpstan
-            -   name: Composer validate
-                run: composer validate
-            -   name: Composer install
-                run: composer install
-            -   name: Run PHPUnit
-                env:
-                    CHECKOUT_PROCESSING_CHANNEL_ID: ${{ secrets.IT_CHECKOUT_PROCESSING_CHANNEL_ID }}
-                    CHECKOUT_PREVIOUS_SECRET_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_SECRET_KEY }}
-                    CHECKOUT_PREVIOUS_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_PUBLIC_KEY }}
-                    CHECKOUT_DEFAULT_SECRET_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_SECRET_KEY }}
-                    CHECKOUT_DEFAULT_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_PUBLIC_KEY }}
-                    CHECKOUT_DEFAULT_OAUTH_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET }}
-                    CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID }}
-                    CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET }}
-                    CHECKOUT_MERCHANT_SUBDOMAIN: ${{ secrets.IT_CHECKOUT_MERCHANT_SUBDOMAIN }}
-                run: vendor/bin/phpunit --verbose
-            -   name: Read release version
-                uses: HardNorth/github-version-generate@v1.1.1
-                with:
-                    version-source: file
-                    version-file: 'version.json'
-                    version-file-extraction-pattern: '"version":\s*"([^"]+)"'
-            -   name: Print release version
-                run: echo "Releasing $CURRENT_VERSION"
-            -   name: Create GitHub release
-                uses: actions/create-release@v1
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                with:
-                    tag_name: ${{ env.CURRENT_VERSION }}
-                    release_name: ${{ env.CURRENT_VERSION }}
-                    body: ${{ github.event.head_commit.message }}
-                    draft: false
-                    prerelease: false
+            - uses: actions/checkout@v2
+
+            - name: Setup PHP 7.1
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "7.1"
+                  coverage: none
+
+            - name: Installed version
+              run: php -v
+
+            - name: Composer validate
+              run: composer validate
+
+            - name: Composer update with promises:^1.5
+              run: |
+                  composer remove guzzlehttp/promises --no-update
+                  composer require guzzlehttp/promises:^1.5 --no-update
+                  composer update --prefer-dist --no-interaction
+
+            - name: Run PHPUnit
+              env:
+                  CHECKOUT_PROCESSING_CHANNEL_ID: ${{ secrets.IT_CHECKOUT_PROCESSING_CHANNEL_ID }}
+                  CHECKOUT_PREVIOUS_SECRET_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_SECRET_KEY }}
+                  CHECKOUT_PREVIOUS_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_PUBLIC_KEY }}
+                  CHECKOUT_DEFAULT_SECRET_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_SECRET_KEY }}
+                  CHECKOUT_DEFAULT_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_PUBLIC_KEY }}
+                  CHECKOUT_DEFAULT_OAUTH_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET }}
+                  CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID }}
+                  CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET }}
+                  CHECKOUT_MERCHANT_SUBDOMAIN: ${{ secrets.IT_CHECKOUT_MERCHANT_SUBDOMAIN }}
+              run: vendor/bin/phpunit --verbose
+
+            - name: Read release version
+              uses: HardNorth/github-version-generate@v1.1.1
+              with:
+                  version-source: file
+                  version-file: 'version.json'
+                  version-file-extraction-pattern: '"version":\s*"([^"]+)"'
+
+            - name: Print release version
+              run: echo "Releasing $CURRENT_VERSION"
+
+            - name: Create GitHub release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: ${{ env.CURRENT_VERSION }}
+                  release_name: ${{ env.CURRENT_VERSION }}
+                  body: ${{ github.event.head_commit.message }}
+                  draft: false
+                  prerelease: false

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 ```json
 {
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.1",
     "checkout/checkout-sdk-php": "version"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1.0",
         "guzzlehttp/guzzle": "^6.5 || ^7.4",
         "monolog/monolog": "^1.27 || ^2.4 || ^3.0.0" ,
         "ext-json": "*",

--- a/lib/Checkout/Events/Previous/EventsClient.php
+++ b/lib/Checkout/Events/Previous/EventsClient.php
@@ -38,7 +38,7 @@ class EventsClient extends Client
      * @return array
      * @throws CheckoutApiException
      */
-    public function retrieveEvents(RetrieveEventsRequest $eventsRequest = null)
+    public function retrieveEvents(?RetrieveEventsRequest $eventsRequest = null)
     {
         return $this->apiClient->query(self::EVENTS_PATH, $eventsRequest, $this->sdkAuthorization());
     }

--- a/lib/Checkout/Payments/PaymentsClient.php
+++ b/lib/Checkout/Payments/PaymentsClient.php
@@ -73,12 +73,12 @@ class PaymentsClient extends Client
 
     /**
      * @param $paymentId
-     * @param CaptureRequest $captureRequest
+     * @param CaptureRequest|null $captureRequest
      * @param string|null $idempotencyKey
      * @return array
      * @throws CheckoutApiException
      */
-    public function capturePayment($paymentId, CaptureRequest $captureRequest = null, $idempotencyKey = null)
+    public function capturePayment($paymentId, ?CaptureRequest $captureRequest = null, $idempotencyKey = null)
     {
         return $this->apiClient->post($this->buildPath(self::PAYMENTS_PATH, $paymentId, "captures"), $captureRequest, $this->sdkAuthorization(), $idempotencyKey);
     }
@@ -90,7 +90,7 @@ class PaymentsClient extends Client
      * @return array
      * @throws CheckoutApiException
      */
-    public function refundPayment($paymentId, RefundRequest $refundRequest = null, $idempotencyKey = null)
+    public function refundPayment($paymentId, ?RefundRequest $refundRequest = null, $idempotencyKey = null)
     {
         return $this->apiClient->post($this->buildPath(self::PAYMENTS_PATH, $paymentId, "refunds"), $refundRequest, $this->sdkAuthorization(), $idempotencyKey);
     }
@@ -102,7 +102,7 @@ class PaymentsClient extends Client
      * @return array
      * @throws CheckoutApiException
      */
-    public function voidPayment($paymentId, VoidRequest $voidRequest = null, $idempotencyKey = null)
+    public function voidPayment($paymentId, ?VoidRequest $voidRequest = null, $idempotencyKey = null)
     {
         return $this->apiClient->post($this->buildPath(self::PAYMENTS_PATH, $paymentId, "voids"), $voidRequest, $this->sdkAuthorization(), $idempotencyKey);
     }
@@ -114,7 +114,7 @@ class PaymentsClient extends Client
      * @return array
      * @throws CheckoutApiException
      */
-    public function incrementPaymentAuthorization($paymentId, AuthorizationRequest $authorizationRequest = null, $idempotencyKey = null)
+    public function incrementPaymentAuthorization($paymentId, ?AuthorizationRequest $authorizationRequest = null, $idempotencyKey = null)
     {
         return $this->apiClient->post($this->buildPath(self::PAYMENTS_PATH, $paymentId, "authorizations"), $authorizationRequest, $this->sdkAuthorization(), $idempotencyKey);
     }

--- a/lib/Checkout/Payments/Previous/PaymentsClient.php
+++ b/lib/Checkout/Payments/Previous/PaymentsClient.php
@@ -80,7 +80,7 @@ class PaymentsClient extends Client
      * @return array
      * @throws CheckoutApiException
      */
-    public function capturePayment($paymentId, CaptureRequest $captureRequest = null, $idempotencyKey = null)
+    public function capturePayment($paymentId, ?CaptureRequest $captureRequest = null, $idempotencyKey = null)
     {
         return $this->apiClient->post($this->buildPath(self::PAYMENTS_PATH, $paymentId, "captures"), $captureRequest, $this->sdkAuthorization(), $idempotencyKey);
     }
@@ -92,7 +92,7 @@ class PaymentsClient extends Client
      * @return array
      * @throws CheckoutApiException
      */
-    public function refundPayment($paymentId, RefundRequest $refundRequest = null, $idempotencyKey = null)
+    public function refundPayment($paymentId, ?RefundRequest $refundRequest = null, $idempotencyKey = null)
     {
         return $this->apiClient->post($this->buildPath(self::PAYMENTS_PATH, $paymentId, "refunds"), $refundRequest, $this->sdkAuthorization(), $idempotencyKey);
     }
@@ -104,7 +104,7 @@ class PaymentsClient extends Client
      * @return array
      * @throws CheckoutApiException
      */
-    public function voidPayment($paymentId, VoidRequest $voidRequest = null, $idempotencyKey = null)
+    public function voidPayment($paymentId, ?VoidRequest $voidRequest = null, $idempotencyKey = null)
     {
         return $this->apiClient->post($this->buildPath(self::PAYMENTS_PATH, $paymentId, "voids"), $voidRequest, $this->sdkAuthorization(), $idempotencyKey);
     }


### PR DESCRIPTION
This is the minimal change required to be PHP 8.4 compatible. I think it would be easier to release this first, to unlock the situation. For the CI I picked what you did and used the last PHP version (8.4) instead of 8.1