### PR TITLE
feat: add Dlocal signature support with parameters for API integration

### DIFF
--- a/lib/Checkout/Forward/Requests/DestinationRequest.php
+++ b/lib/Checkout/Forward/Requests/DestinationRequest.php
@@ -2,6 +2,8 @@
 
 namespace Checkout\Forward\Requests;
 
+use Checkout\Forward\Requests\Signatures\AbstractSignature;
+
 class DestinationRequest
 {
     /**
@@ -33,4 +35,12 @@ class DestinationRequest
      * @var string
      */
     public $body;
+
+    /**
+     * Optional configuration to add a signature to the forwarded HTTP request. (Optional)
+     *
+     * @var AbstractSignature
+     */
+    public $signature;
+
 }

--- a/lib/Checkout/Forward/Requests/Signatures/AbstractSignature.php
+++ b/lib/Checkout/Forward/Requests/Signatures/AbstractSignature.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Checkout\Forward\Requests\Signatures;
+
+class AbstractSignature
+{
+    /**
+     * The identifier of the supported signature generation method or a specific third-party service. (Required)
+     *
+     * @var string value of SignatureType
+     */
+    public $type;
+
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/lib/Checkout/Forward/Requests/Signatures/DlocalParameters.php
+++ b/lib/Checkout/Forward/Requests/Signatures/DlocalParameters.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Checkout\Forward\Requests\Signatures;
+
+class DlocalParameters
+{
+    /**
+     * The secret key used to generate the request signature. This is part of the dLocal API credentials.
+     *
+     * @var string
+     */
+    public $secret_key;
+}

--- a/lib/Checkout/Forward/Requests/Signatures/DlocalSignature.php
+++ b/lib/Checkout/Forward/Requests/Signatures/DlocalSignature.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Checkout\Forward\Requests\Signatures;
+
+use Checkout\Forward\Requests\Sources\SourceType;
+
+class DlocalSignature extends AbstractSignature
+{
+    /**
+     * The parameters required to generate an HMAC signature for the dLocal API. See their documentation for details.
+     * This method requires you to provide the X-Login header value in the destination request headers.
+     * When used, the Forward API appends the X-Date and Authorization headers to the outgoing HTTP request before
+     * forwarding.
+     *
+     * @var DlocalParameters
+     */
+    public $dlocal_parameters;
+
+    /**
+     * Initializes a new instance of the DlocalSignature class.
+     */
+    public function __construct()
+    {
+        parent::__construct(SignatureType::$dlocal);
+    }
+}

--- a/lib/Checkout/Forward/Requests/Signatures/SignatureType.php
+++ b/lib/Checkout/Forward/Requests/Signatures/SignatureType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Checkout\Forward\Requests\Signatures;
+
+final class SignatureType
+{
+    public static $dlocal = "dlocal";
+}

--- a/test/Checkout/Tests/Forward/ForwardIntegrationTest.php
+++ b/test/Checkout/Tests/Forward/ForwardIntegrationTest.php
@@ -11,6 +11,8 @@ use Checkout\Forward\Requests\ForwardRequest;
 use Checkout\Forward\Requests\Headers;
 use Checkout\Forward\Requests\MethodType;
 use Checkout\Forward\Requests\NetworkToken;
+use Checkout\Forward\Requests\Signatures\DlocalParameters;
+use Checkout\Forward\Requests\Signatures\DlocalSignature;
 use Checkout\Forward\Requests\Sources\IdSource;
 use Checkout\PlatformType;
 use Checkout\Tests\SandboxTestFixture;
@@ -96,6 +98,13 @@ class ForwardIntegrationTest extends SandboxTestFixture
         );
         $headers->encrypted = "<JWE encrypted JSON object with string values>";
 
+        $dlocalParameters = new DlocalParameters();
+        $dlocalParameters->secret_key = "9f439fe1a9f96e67b047d3c1a28c33a2e";
+
+        $signature = new DlocalSignature();
+        $signature->dlocal_parameters = $dlocalParameters;
+
+
         $destinationRequest = new DestinationRequest();
         $destinationRequest->url = "https://example.com/payments";
         $destinationRequest->method = MethodType::$post;
@@ -118,6 +127,7 @@ class ForwardIntegrationTest extends SandboxTestFixture
             "risk" => array("enabled" => false),
             "merchant_initiated" => true
         ));
+        $destinationRequest->signature = $signature;
 
         $networkToken = new NetworkToken();
         $networkToken->enabled = true;


### PR DESCRIPTION
This pull request introduces the ability to add signatures to forwarded HTTP requests in the `Forward API`. It includes changes to support signature configuration, specifically for dLocal HMAC signatures, and updates the integration tests to validate this functionality.

### Signature Configuration Enhancements:
* [`lib/Checkout/Forward/Requests/DestinationRequest.php`](diffhunk://#diff-8845682d2fa7da846a0b153ca1e43d3939c8691c597bdb1aa83ff3e45f36008eR38-R45): Added an optional `signature` property to the `DestinationRequest` class, allowing configuration of signatures for forwarded HTTP requests.
* [`lib/Checkout/Forward/Requests/Signatures/AbstractSignature.php`](diffhunk://#diff-114ad800482f98d415941138f7ef69ec31e114453027e0bf6f093bdbc9881275R1-R16): Created the `AbstractSignature` class to serve as a base for signature implementations, with a `type` property for specifying the signature type.
* [`lib/Checkout/Forward/Requests/Signatures/DlocalSignature.php`](diffhunk://#diff-f64bc856bdf5992ad62431f8793b9d6925500319b092367fc06fcc80aef4e0bdR1-R26): Added the `DlocalSignature` class, inheriting from `AbstractSignature`, to handle dLocal HMAC signatures with required parameters encapsulated in the `DlocalParameters` class. [[1]](diffhunk://#diff-f64bc856bdf5992ad62431f8793b9d6925500319b092367fc06fcc80aef4e0bdR1-R26) [[2]](diffhunk://#diff-33a16d0aa1d0c7761a9d2ba9cd33cdbead29e3a836197106edaa60d870365042R1-R8)
* [`lib/Checkout/Forward/Requests/Signatures/SignatureType.php`](diffhunk://#diff-322a18fbef1e34a64cce37364897eb269e45904097c693667ffe99ee411cee3eR1-R8): Introduced the `SignatureType` class to define constants for supported signature types, such as `dlocal`.

### Integration Test Updates:
* [`test/Checkout/Tests/Forward/ForwardIntegrationTest.php`](diffhunk://#diff-fb0718d4b1573773eb580fc774ed0dec7fc30168c911775948751997d1048a1fR101-R107): Updated the `createForwardRequest()` method to include a dLocal signature configuration, demonstrating how to set up and use the new signature functionality in integration tests. [[1]](diffhunk://#diff-fb0718d4b1573773eb580fc774ed0dec7fc30168c911775948751997d1048a1fR101-R107) [[2]](diffhunk://#diff-fb0718d4b1573773eb580fc774ed0dec7fc30168c911775948751997d1048a1fR130)