### PR TITLE
Incorrect PHPDoc type for $allow_payment_methods in HostedPaymentsSessionRequest.php

### DIFF
--- a/lib/Checkout/Payments/Hosted/HostedPaymentsSessionRequest.php
+++ b/lib/Checkout/Payments/Hosted/HostedPaymentsSessionRequest.php
@@ -134,7 +134,7 @@ class HostedPaymentsSessionRequest
     public $billing_descriptor;
 
     /**
-     * @var string value of PaymentSourceType
+     * @var string[] value of PaymentSourceType
      */
     public $allow_payment_methods;
 


### PR DESCRIPTION
## Fixes #317:

### Description
The PHPDoc type for `$allow_payment_methods` is incorrect in:  
`lib/Checkout/Payments/Hosted/HostedPaymentsSessionRequest.php`

### Expected Behavior
The type should be `string[]`, as specified in the documentation:  
[createAHostedPaymentsSession allow_payment_methods](https://api-reference.checkout.com/#operation/createAHostedPaymentsSession!path=allow_payment_methods&t=request)

### Solution
The API works correctly when an array of strings is used.
The type in the PHPDoc is just inaccurate. I will provide a fix in a pull request.