### PR TITLE
GooglePay fields to snake case update

### DIFF
--- a/lib/Checkout/Payments/GooglePay/Requests/GooglePayEnrollmentRequest.php
+++ b/lib/Checkout/Payments/GooglePay/Requests/GooglePayEnrollmentRequest.php
@@ -14,7 +14,7 @@ class GooglePayEnrollmentRequest
      *
      * @var string
      */
-    public $entityId;
+    public $entity_id;
 
     /**
      * The email address of the user accepting the Google terms of service for this feature.
@@ -22,7 +22,7 @@ class GooglePayEnrollmentRequest
      *
      * @var string
      */
-    public $emailAddress;
+    public $email_address;
 
     /**
      * Indicates acceptance of the Google terms of service. Must be true to proceed with enrollment.
@@ -30,5 +30,5 @@ class GooglePayEnrollmentRequest
      *
      * @var bool
      */
-    public $acceptTermsOfService;
+    public $accept_terms_of_service;
 }

--- a/lib/Checkout/Payments/GooglePay/Requests/GooglePayRegisterDomainRequest.php
+++ b/lib/Checkout/Payments/GooglePay/Requests/GooglePayRegisterDomainRequest.php
@@ -14,5 +14,5 @@ class GooglePayRegisterDomainRequest
      *
      * @var string
      */
-    public $webDomain;
+    public $web_domain;
 }

--- a/test/Checkout/Tests/Payments/GooglePay/GooglePayClientTest.php
+++ b/test/Checkout/Tests/Payments/GooglePay/GooglePayClientTest.php
@@ -161,32 +161,32 @@ class GooglePayClientTest extends UnitTestFixture
     private function buildValidEnrollmentRequest(): GooglePayEnrollmentRequest
     {
         $request = new GooglePayEnrollmentRequest();
-        $request->entityId = "ent_test123456789";
-        $request->emailAddress = "test@example.com";
-        $request->acceptTermsOfService = true;
+        $request->entity_id = "ent_test123456789";
+        $request->email_address = "test@example.com";
+        $request->accept_terms_of_service = true;
         return $request;
     }
 
     private function buildMinimalEnrollmentRequest(): GooglePayEnrollmentRequest
     {
         $request = new GooglePayEnrollmentRequest();
-        $request->entityId = "ent_minimal123";
-        $request->emailAddress = "minimal@test.com";
-        $request->acceptTermsOfService = true;
+        $request->entity_id = "ent_minimal123";
+        $request->email_address = "minimal@test.com";
+        $request->accept_terms_of_service = true;
         return $request;
     }
 
     private function buildValidRegisterDomainRequest(): GooglePayRegisterDomainRequest
     {
         $request = new GooglePayRegisterDomainRequest();
-        $request->webDomain = "example.com";
+        $request->web_domain = "example.com";
         return $request;
     }
 
     private function buildRegisterDomainRequestWithSubdomain(): GooglePayRegisterDomainRequest
     {
         $request = new GooglePayRegisterDomainRequest();
-        $request->webDomain = "shop.example.com";
+        $request->web_domain = "shop.example.com";
         return $request;
     }
 

--- a/test/Checkout/Tests/Payments/GooglePay/GooglePayIntegrationTest.php
+++ b/test/Checkout/Tests/Payments/GooglePay/GooglePayIntegrationTest.php
@@ -109,7 +109,7 @@ class GooglePayIntegrationTest extends SandboxTestFixture
 
         // Verify the domain we registered is in the list
         $registeredDomains = array_column($domainsResponse["domains"], "web_domain");
-        $this->assertTrue(in_array($domainRequest->webDomain, $registeredDomains));
+        $this->assertTrue(in_array($domainRequest->web_domain, $registeredDomains));
     }
 
     /**
@@ -125,7 +125,7 @@ class GooglePayIntegrationTest extends SandboxTestFixture
 
         foreach ($domains as $domain) {
             $request = new GooglePayRegisterDomainRequest();
-            $request->webDomain = $domain;
+            $request->web_domain = $domain;
             
             $response = $this->checkoutApi->getGooglePayClient()->registerDomain($entityId, $request);
             $this->validateRegisterDomainResponse($response, $request);
@@ -145,23 +145,23 @@ class GooglePayIntegrationTest extends SandboxTestFixture
     private function buildValidEnrollmentRequest(): GooglePayEnrollmentRequest
     {
         $request = new GooglePayEnrollmentRequest();
-        $request->entityId = "ent_uzm3uxtssvmuxnyrfdffcyjxeu"; // Use valid entity ID
-        $request->emailAddress = "test@example.com";
-        $request->acceptTermsOfService = true;
+        $request->entity_id = "ent_uzm3uxtssvmuxnyrfdffcyjxeu"; // Use valid entity ID
+        $request->email_address = "test@example.com";
+        $request->accept_terms_of_service = true;
         return $request;
     }
 
     private function buildValidRegisterDomainRequest(): GooglePayRegisterDomainRequest
     {
         $request = new GooglePayRegisterDomainRequest();
-        $request->webDomain = "example.com"; // Must be owned and verified domain
+        $request->web_domain = "example.com"; // Must be owned and verified domain
         return $request;
     }
 
     private function buildRegisterDomainRequestForSubdomain(string $subdomain): GooglePayRegisterDomainRequest
     {
         $request = new GooglePayRegisterDomainRequest();
-        $request->webDomain = $subdomain . ".example.com";
+        $request->web_domain = $subdomain . ".example.com";
         return $request;
     }
 
@@ -182,7 +182,7 @@ class GooglePayIntegrationTest extends SandboxTestFixture
     {
         $this->assertResponse($response, "web_domain", "status");
         
-        $this->assertEquals($originalRequest->webDomain, $response["web_domain"]);
+        $this->assertEquals($originalRequest->web_domain, $response["web_domain"]);
         $this->assertTrue(in_array($response["status"], ["registered", "pending", "verified"]));
         
         if (isset($response["registered_on"])) {


### PR DESCRIPTION
This pull request updates the naming conventions for request class properties in the Google Pay integration to use snake_case instead of camelCase. This change improves consistency and aligns with common PHP coding standards.

**Property renaming for consistency:**

* Renamed properties in `GooglePayEnrollmentRequest` from camelCase to snake_case: `entityId` → `entity_id`, `emailAddress` → `email_address`, and `acceptTermsOfService` → `accept_terms_of_service`.
* Renamed the `webDomain` property to `web_domain` in `GooglePayRegisterDomainRequest`.…ake-case)