### PR TITLE
fix: correct PHPDoc type for $disabled_payment_methods in HostedPaymentsSessionRequest

### DIFF
--- a/lib/Checkout/Payments/Hosted/HostedPaymentsSessionRequest.php
+++ b/lib/Checkout/Payments/Hosted/HostedPaymentsSessionRequest.php
@@ -139,7 +139,7 @@ class HostedPaymentsSessionRequest
     public $allow_payment_methods;
 
     /**
-     * @var string value of PaymentSourceType
+     * @var string[] values of PaymentSourceType
      */
     public $disabled_payment_methods;
 


### PR DESCRIPTION
## Summary

- Same `@var string` typo as #317 (fixed in #318) — `$disabled_payment_methods` also accepts an array, not a single string.
- Corrected to `@var string[] values of PaymentSourceType` to match the API spec (`PaymentInterfacesPaymentMethods` → array of string enum).

## Related

Follows up on #318 / closes #317 (the sibling field in the same class).