### PR TITLE
fix: route forward and identity clients to dedicated base URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ vendor/*
 .cursor
 .vscode
 composer
+
+.claude/
+CLAUDE.md

--- a/lib/Checkout/CheckoutApi.php
+++ b/lib/Checkout/CheckoutApi.php
@@ -123,26 +123,12 @@ final class CheckoutApi extends CheckoutApmApi
             $this->getForwardApiClient($configuration),
             $configuration
         );
-        $this->faceAuthenticationClient = new FaceAuthenticationClient(
-            $this->getIdentityApiClient($configuration),
-            $configuration
-        );
-        $this->idDocumentVerificationClient = new IdDocumentVerificationClient(
-            $this->getIdentityApiClient($configuration),
-            $configuration
-        );
-        $this->identityVerificationClient = new IdentityVerificationClient(
-            $this->getIdentityApiClient($configuration),
-            $configuration
-        );
-        $this->amlScreeningClient = new AmlScreeningClient(
-            $this->getIdentityApiClient($configuration),
-            $configuration
-        );
-        $this->applicantsClient = new ApplicantsClient(
-            $this->getIdentityApiClient($configuration),
-            $configuration
-        );
+        $identityApiClient = $this->getIdentityApiClient($configuration);
+        $this->faceAuthenticationClient = new FaceAuthenticationClient($identityApiClient, $configuration);
+        $this->idDocumentVerificationClient = new IdDocumentVerificationClient($identityApiClient, $configuration);
+        $this->identityVerificationClient = new IdentityVerificationClient($identityApiClient, $configuration);
+        $this->amlScreeningClient = new AmlScreeningClient($identityApiClient, $configuration);
+        $this->applicantsClient = new ApplicantsClient($identityApiClient, $configuration);
         $this->balancesClient = new BalancesClient(
             $this->getBalancesApiClient($configuration),
             $configuration

--- a/lib/Checkout/CheckoutApi.php
+++ b/lib/Checkout/CheckoutApi.php
@@ -119,12 +119,30 @@ final class CheckoutApi extends CheckoutApmApi
         $this->paymentContextClient = new PaymentContextsClient($baseApiClient, $configuration);
         $this->paymentSessionsClient = new PaymentSessionsClient($baseApiClient, $configuration);
         $this->paymentSetupsClient = new PaymentSetupsClient($baseApiClient, $configuration);
-        $this->forwardClient = new ForwardClient($baseApiClient, $configuration);
-        $this->faceAuthenticationClient = new FaceAuthenticationClient($baseApiClient, $configuration);
-        $this->idDocumentVerificationClient = new IdDocumentVerificationClient($baseApiClient, $configuration);
-        $this->identityVerificationClient = new IdentityVerificationClient($baseApiClient, $configuration);
-        $this->amlScreeningClient = new AmlScreeningClient($baseApiClient, $configuration);
-        $this->applicantsClient = new ApplicantsClient($baseApiClient, $configuration);
+        $this->forwardClient = new ForwardClient(
+            $this->getForwardApiClient($configuration),
+            $configuration
+        );
+        $this->faceAuthenticationClient = new FaceAuthenticationClient(
+            $this->getIdentityApiClient($configuration),
+            $configuration
+        );
+        $this->idDocumentVerificationClient = new IdDocumentVerificationClient(
+            $this->getIdentityApiClient($configuration),
+            $configuration
+        );
+        $this->identityVerificationClient = new IdentityVerificationClient(
+            $this->getIdentityApiClient($configuration),
+            $configuration
+        );
+        $this->amlScreeningClient = new AmlScreeningClient(
+            $this->getIdentityApiClient($configuration),
+            $configuration
+        );
+        $this->applicantsClient = new ApplicantsClient(
+            $this->getIdentityApiClient($configuration),
+            $configuration
+        );
         $this->balancesClient = new BalancesClient(
             $this->getBalancesApiClient($configuration),
             $configuration
@@ -464,5 +482,23 @@ final class CheckoutApi extends CheckoutApmApi
     private function getBalancesApiClient(CheckoutConfiguration $configuration)
     {
         return new ApiClient($configuration, $configuration->getEnvironment()->getBalancesUri());
+    }
+
+    /**
+     * @param CheckoutConfiguration $configuration
+     * @return ApiClient
+     */
+    private function getForwardApiClient(CheckoutConfiguration $configuration)
+    {
+        return new ApiClient($configuration, $configuration->getEnvironment()->getForwardUri());
+    }
+
+    /**
+     * @param CheckoutConfiguration $configuration
+     * @return ApiClient
+     */
+    private function getIdentityApiClient(CheckoutConfiguration $configuration)
+    {
+        return new ApiClient($configuration, $configuration->getEnvironment()->getIdentityUri());
     }
 }

--- a/lib/Checkout/Environment.php
+++ b/lib/Checkout/Environment.php
@@ -9,6 +9,8 @@ final class Environment
     private $filesBaseUri;
     private $transfersUri;
     private $balancesUri;
+    private $forwardUri;
+    private $identityUri;
     private $isSandbox;
 
     /**
@@ -17,6 +19,8 @@ final class Environment
      * @param string $filesBaseUrl
      * @param string $transfersUri
      * @param string $balancesUri
+     * @param string $forwardUri
+     * @param string $identityUri
      * @param bool $isSandbox
      */
     private function __construct(
@@ -25,6 +29,8 @@ final class Environment
         $filesBaseUrl,
         $transfersUri,
         $balancesUri,
+        $forwardUri,
+        $identityUri,
         $isSandbox
     ) {
         $this->baseUri = $baseUri;
@@ -32,6 +38,8 @@ final class Environment
         $this->filesBaseUri = $filesBaseUrl;
         $this->transfersUri = $transfersUri;
         $this->balancesUri = $balancesUri;
+        $this->forwardUri = $forwardUri;
+        $this->identityUri = $identityUri;
         $this->isSandbox = $isSandbox;
     }
 
@@ -46,6 +54,8 @@ final class Environment
             "https://files.sandbox.checkout.com/",
             "https://transfers.sandbox.checkout.com/",
             "https://balances.sandbox.checkout.com/",
+            "https://forward.sandbox.checkout.com/",
+            "https://identity-verification.sandbox.checkout.com/",
             true
         );
     }
@@ -62,6 +72,8 @@ final class Environment
             "https://files.checkout.com/",
             "https://transfers.checkout.com/",
             "https://balances.checkout.com/",
+            "https://forward.checkout.com/",
+            "https://identity-verification.checkout.com/",
             false
         );
     }
@@ -112,5 +124,21 @@ final class Environment
     public function getBalancesUri()
     {
         return $this->balancesUri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getForwardUri()
+    {
+        return $this->forwardUri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentityUri()
+    {
+        return $this->identityUri;
     }
 }

--- a/lib/Checkout/EnvironmentSubdomain.php
+++ b/lib/Checkout/EnvironmentSubdomain.php
@@ -30,7 +30,7 @@ final class EnvironmentSubdomain
     {
         $newEnvironment = $originalUrl;
 
-        $regex = '/^[a-z0-9]+(-[a-z0-9]+)*$/';
+        $regex = '/^(?:pl-)?[a-z0-9]+$/';
         if (preg_match($regex, $subdomain)) {
             $urlParts = parse_url($originalUrl);
             $newHost = $subdomain . '.' . $urlParts['host'];

--- a/lib/Checkout/EnvironmentSubdomain.php
+++ b/lib/Checkout/EnvironmentSubdomain.php
@@ -30,7 +30,7 @@ final class EnvironmentSubdomain
     {
         $newEnvironment = $originalUrl;
 
-        $regex = '/^[0-9a-z]+$/';
+        $regex = '/^[a-z0-9]+(-[a-z0-9]+)*$/';
         if (preg_match($regex, $subdomain)) {
             $urlParts = parse_url($originalUrl);
             $newHost = $subdomain . '.' . $urlParts['host'];

--- a/lib/Checkout/OAuthScope.php
+++ b/lib/Checkout/OAuthScope.php
@@ -36,6 +36,7 @@ class OAuthScope
     public static $GatewayPaymentDetails = "gateway:payment-details";
     public static $GatewayPaymentRefunds = "gateway:payment-refunds";
     public static $GatewayPaymentVoids = "gateway:payment-voids";
+    public static $IdentityVerification = "identity-verification";
     public static $IssuingCardManagementRead = "issuing:card-management-read";
     public static $IssuingCardManagementWrite = "issuing:card-management-write";
     public static $IssuingCardMgmt = "issuing:card-mgmt";

--- a/test/Checkout/Tests/CheckoutConfigurationTests.php
+++ b/test/Checkout/Tests/CheckoutConfigurationTests.php
@@ -83,6 +83,8 @@ class CheckoutConfigurationTests extends MockeryTestCase
             ["abc", "https://abc.api.sandbox.checkout.com/", "https://abc.access.sandbox.checkout.com/connect/token"],
             ["abc1", "https://abc1.api.sandbox.checkout.com/", "https://abc1.access.sandbox.checkout.com/connect/token"],
             ["12345domain", "https://12345domain.api.sandbox.checkout.com/", "https://12345domain.access.sandbox.checkout.com/connect/token"],
+            ["test-123", "https://test-123.api.sandbox.checkout.com/", "https://test-123.access.sandbox.checkout.com/connect/token"],
+            ["pl-abc123", "https://pl-abc123.api.sandbox.checkout.com/", "https://pl-abc123.access.sandbox.checkout.com/connect/token"],
         ];
     }
 
@@ -95,6 +97,9 @@ class CheckoutConfigurationTests extends MockeryTestCase
             [" - ", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
             ["a b", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
             ["ab c1.", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
+            ["foo-", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
+            ["-foo", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
+            ["ABC", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
         ];
     }
 
@@ -126,4 +131,19 @@ class CheckoutConfigurationTests extends MockeryTestCase
         $this->assertEquals("https://1234prod.api.checkout.com/", $configuration->getEnvironmentSubdomain()->getBaseUri());
         $this->assertEquals("https://1234prod.access.checkout.com/connect/token", $configuration->getEnvironmentSubdomain()->getAuthorizationUri());
     }
+
+    public function testEnvironmentSandboxHasCorrectForwardAndIdentityUrls()
+    {
+        $env = Environment::sandbox();
+        $this->assertEquals("https://forward.sandbox.checkout.com/", $env->getForwardUri());
+        $this->assertEquals("https://identity-verification.sandbox.checkout.com/", $env->getIdentityUri());
+    }
+
+    public function testEnvironmentProductionHasCorrectForwardAndIdentityUrls()
+    {
+        $env = Environment::production();
+        $this->assertEquals("https://forward.checkout.com/", $env->getForwardUri());
+        $this->assertEquals("https://identity-verification.checkout.com/", $env->getIdentityUri());
+    }
+
 }

--- a/test/Checkout/Tests/CheckoutConfigurationTests.php
+++ b/test/Checkout/Tests/CheckoutConfigurationTests.php
@@ -83,7 +83,7 @@ class CheckoutConfigurationTests extends MockeryTestCase
             ["abc", "https://abc.api.sandbox.checkout.com/", "https://abc.access.sandbox.checkout.com/connect/token"],
             ["abc1", "https://abc1.api.sandbox.checkout.com/", "https://abc1.access.sandbox.checkout.com/connect/token"],
             ["12345domain", "https://12345domain.api.sandbox.checkout.com/", "https://12345domain.access.sandbox.checkout.com/connect/token"],
-            ["test-123", "https://test-123.api.sandbox.checkout.com/", "https://test-123.access.sandbox.checkout.com/connect/token"],
+            ["pl-vkuhvk4v", "https://pl-vkuhvk4v.api.sandbox.checkout.com/", "https://pl-vkuhvk4v.access.sandbox.checkout.com/connect/token"],
             ["pl-abc123", "https://pl-abc123.api.sandbox.checkout.com/", "https://pl-abc123.access.sandbox.checkout.com/connect/token"],
         ];
     }
@@ -100,6 +100,9 @@ class CheckoutConfigurationTests extends MockeryTestCase
             ["foo-", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
             ["-foo", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
             ["ABC", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
+            ["test-123", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
+            ["foo-bar", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
+            ["pl-", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token"],
         ];
     }
 

--- a/test/Checkout/Tests/CheckoutDefaultSdkTest.php
+++ b/test/Checkout/Tests/CheckoutDefaultSdkTest.php
@@ -97,7 +97,7 @@ class CheckoutDefaultSdkTest extends UnitTestFixture
     public function shouldInstantiateClientWithCustomHttpClient()
     {
         $httpBuilder = $this->createMock(HttpClientBuilderInterface::class);
-        $httpBuilder->expects($this->exactly(4))->method("getClient");
+        $httpBuilder->expects($this->exactly(6))->method("getClient");
 
         $this->assertNotNull(CheckoutSdk::builder()
             ->staticKeys()


### PR DESCRIPTION
## Summary

The forward service and the identity-verification services (face authentication, ID document verification, identity verification, AML screening, applicants) live on their own hosts in the swagger spec, not under `api.checkout.com`. This PR adds dedicated URIs for both and routes the corresponding clients through them. It also tightens the subdomain validation regex to match the AWS PrivateLink prefix format documented at https://www.checkout.com/docs/developer-resources/api/private-connections/aws-privatelink — `^(?:pl-)?[a-z0-9]+$` (alphanumeric, optionally prefixed by the literal `pl-`). Finally, it exposes the `identity-verification` OAuth scope as a typed constant.

## Changes

- `lib/Checkout/Environment.php` — adds `$forwardUri` and `$identityUri` fields, constructor parameters, `getForwardUri()`/`getIdentityUri()` accessors, sandbox/production values
- `lib/Checkout/CheckoutApi.php` — adds `getForwardApiClient` and `getIdentityApiClient` helpers; routes `forwardClient` to forward URI; caches the identity `ApiClient` once and reuses it across `faceAuthenticationClient`, `idDocumentVerificationClient`, `identityVerificationClient`, `amlScreeningClient`, `applicantsClient`
- `lib/Checkout/OAuthScope.php` — adds `public static $IdentityVerification = "identity-verification"`
- `lib/Checkout/EnvironmentSubdomain.php` — tightens regex to `/^(?:pl-)?[a-z0-9]+$/`
- `test/Checkout/Tests/CheckoutConfigurationTests.php` — updates subdomain corpus: removes `test-123` from accepted, adds `pl-vkuhvk4v` (docs example), adds `test-123`/`foo-bar`/`pl-` to rejected; adds `testEnvironmentSandboxHasCorrectForwardAndIdentityUrls` / `testEnvironmentProductionHasCorrectForwardAndIdentityUrls`
- `test/Checkout/Tests/CheckoutDefaultSdkTest.php` — updates `shouldInstantiateClientWithCustomHttpClient` mock expectation from `exactly(4)` to `exactly(6)` (base, files, transfers, balances, forward, identity)

## API Reference

- `https://forward.checkout.com` / `https://forward.sandbox.checkout.com` — forward service (`POST /forward` *(beta)*, `GET /forward/{id}` *(beta)*, `POST /forward/secrets`, `GET|POST|DELETE /forward/secrets/{name}`). Scopes: `forward` (plus `forward:secrets` for secrets endpoints).
- `https://identity-verification.checkout.com` / `https://identity-verification.sandbox.checkout.com` — identity services (`/applicants`, `/identity-verifications` *(beta)*, `/aml-verifications` *(beta)*, `/face-authentications` *(beta)*, `/id-document-verifications` *(beta)*). Scope: `identity-verification`.
- `https://pl-{prefix}.api.{sandbox.,}checkout.com` — AWS PrivateLink subdomain format

## Breaking changes

- None for SDK consumers from the URL split — `Environment` is constructed internally via the `Environment::sandbox()` / `Environment::production()` factories.
- The subdomain regex is now stricter: arbitrary hyphenated subdomains like `test-123` or `foo-bar-baz` are rejected. Only plain alphanumeric or the literal PrivateLink form (`pl-{prefix}`) are accepted.

## README

Not affected.