### PR TITLE
chore(ci): bump PHP 8.4 to 8.4.20 in Windows CI build

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -84,7 +84,7 @@ jobs:
                       "7.1" { $downloadUrl = "https://downloads.php.net/~windows/releases/archives/php-7.1.33-Win32-VC14-x64.zip" }
                       "7.4" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-7.4.33-Win32-vc15-x64.zip" }
                       "8.1" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-8.1.34-Win32-vs16-x64.zip" }
-                      "8.4" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-8.4.19-Win32-vs17-x64.zip" }
+                      "8.4" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-8.4.20-Win32-vs17-x64.zip" }
                       default { throw "Unsupported PHP version: $phpVersion" }
                   }
                   


### PR DESCRIPTION
## Summary

The Windows job in `build-master.yml` downloads PHP 8.4 from `downloads.php.net`. Release 8.4.19 has been rotated out of the `releases/` directory, breaking the job. Bumps the URL to the current 8.4.20 release.

## Changes

- `.github/workflows/build-master.yml` — updates the PHP 8.4 Windows download URL from `php-8.4.19-Win32-vs17-x64.zip` to `php-8.4.20-Win32-vs17-x64.zip`

## API Reference

Not applicable — CI only.

## Breaking changes

None.

## README

Not affected.