### PR TITLE
Updated payment source types + unit tests

### DIFF
--- a/lib/Checkout/Common/AccountHolderAch.php
+++ b/lib/Checkout/Common/AccountHolderAch.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Checkout\Common;
+
+/**
+ * Account holder details for ACH payment sources.
+ *
+ * Mirrors the `AccountHolderAch` schema in the swagger spec — a narrower shape
+ * than {@see AccountHolder}, with only the fields the API accepts for ACH.
+ */
+class AccountHolderAch
+{
+    /**
+     * @var string value of AccountHolderType (individual, corporate, government)
+     */
+    public $type;
+
+    /**
+     * @var string
+     */
+    public $first_name;
+
+    /**
+     * @var string
+     */
+    public $last_name;
+
+    /**
+     * @var string
+     */
+    public $company_name;
+
+    /**
+     * @var Address
+     */
+    public $billing_address;
+
+    /**
+     * @var string
+     */
+    public $date_of_birth;
+
+    /**
+     * @var AccountHolderIdentification
+     */
+    public $identification;
+}

--- a/lib/Checkout/Common/PaymentSourceType.php
+++ b/lib/Checkout/Common/PaymentSourceType.php
@@ -52,4 +52,15 @@ class PaymentSourceType
     public static $trustly = "trustly";
     public static $cvconnect = "cvconnect";
     public static $sepa = "sepa";
+    public static $bizum = "bizum";
+    public static $ach = "ach";
+    public static $blik = "blik";
+    public static $mobilepay = "mobilepay";
+    public static $octopus = "octopus";
+    public static $paynow = "paynow";
+    public static $plaid = "plaid";
+    public static $sequra = "sequra";
+    public static $swish = "swish";
+    public static $twint = "twint";
+    public static $vipps = "vipps";
 }

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestAchSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestAchSource.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\AccountHolder;
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestAchSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$ach);
+    }
+
+    /**
+     * @var string value of AccountType (savings, checking, cash)
+     */
+    public $account_type;
+
+    /**
+     * @var string values of Country
+     */
+    public $country;
+
+    /**
+     * @var string
+     */
+    public $account_number;
+
+    /**
+     * @var string
+     */
+    public $bank_code;
+
+    /**
+     * @var AccountHolder
+     */
+    public $account_holder;
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestAchSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestAchSource.php
@@ -2,7 +2,7 @@
 
 namespace Checkout\Payments\Request\Source\Apm;
 
-use Checkout\Common\AccountHolder;
+use Checkout\Common\AccountHolderAch;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Request\Source\AbstractRequestSource;
 
@@ -34,7 +34,7 @@ class RequestAchSource extends AbstractRequestSource
     public $bank_code;
 
     /**
-     * @var AccountHolder
+     * @var AccountHolderAch
      */
     public $account_holder;
 }

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestAlipayCnSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestAlipayCnSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestAlipayCnSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$alipay_cn);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestAlipayHkSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestAlipayHkSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestAlipayHkSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$alipay_hk);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestAlipayPlusSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestAlipayPlusSource.php
@@ -7,44 +7,94 @@ use Checkout\Payments\Request\Source\AbstractRequestSource;
 
 class RequestAlipayPlusSource extends AbstractRequestSource
 {
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$alipay_plus);
+    }
+
+    /**
+     * @deprecated Use {@see RequestAlipayPlusSource} constructor directly: `new RequestAlipayPlusSource()`.
+     *             Will be removed in the next major version.
+     */
     public static function requestAlipayPlusSource()
     {
-        return new RequestAlipayPlusSource(PaymentSourceType::$alipay_plus);
+        return new RequestAlipayPlusSource();
     }
 
+    /**
+     * @deprecated Use {@see RequestAlipayCnSource} instead.
+     *             Will be removed in the next major version.
+     */
     public static function requestAlipayPlusCNSource()
     {
-        return new RequestAlipayPlusSource(PaymentSourceType::$alipay_cn);
+        $source = new RequestAlipayPlusSource();
+        $source->type = PaymentSourceType::$alipay_cn;
+        return $source;
     }
 
+    /**
+     * @deprecated Use {@see RequestGcashSource} instead.
+     *             Will be removed in the next major version.
+     */
     public static function requestAlipayPlusGCashSource()
     {
-        return new RequestAlipayPlusSource(PaymentSourceType::$gcash);
+        $source = new RequestAlipayPlusSource();
+        $source->type = PaymentSourceType::$gcash;
+        return $source;
     }
 
+    /**
+     * @deprecated Use {@see RequestAlipayHkSource} instead.
+     *             Will be removed in the next major version.
+     */
     public static function requestAlipayPlusHKSource()
     {
-        return new RequestAlipayPlusSource(PaymentSourceType::$alipay_hk);
+        $source = new RequestAlipayPlusSource();
+        $source->type = PaymentSourceType::$alipay_hk;
+        return $source;
     }
 
+    /**
+     * @deprecated Use {@see RequestDanaSource} instead.
+     *             Will be removed in the next major version.
+     */
     public static function requestAlipayPlusDanaSource()
     {
-        return new RequestAlipayPlusSource(PaymentSourceType::$dana);
+        $source = new RequestAlipayPlusSource();
+        $source->type = PaymentSourceType::$dana;
+        return $source;
     }
 
+    /**
+     * @deprecated Use {@see RequestKakaopaySource} instead.
+     *             Will be removed in the next major version.
+     */
     public static function requestAlipayPlusKakaoPaySource()
     {
-        return new RequestAlipayPlusSource(PaymentSourceType::$kakaopay);
+        $source = new RequestAlipayPlusSource();
+        $source->type = PaymentSourceType::$kakaopay;
+        return $source;
     }
 
+    /**
+     * @deprecated Use {@see RequestTruemoneySource} instead.
+     *             Will be removed in the next major version.
+     */
     public static function requestAlipayPlusTrueMoneySource()
     {
-        return new RequestAlipayPlusSource(PaymentSourceType::$truemoney);
+        $source = new RequestAlipayPlusSource();
+        $source->type = PaymentSourceType::$truemoney;
+        return $source;
     }
 
+    /**
+     * @deprecated Use {@see RequestTngSource} instead.
+     *             Will be removed in the next major version.
+     */
     public static function requestAlipayPlusTNGSource()
     {
-        return new RequestAlipayPlusSource(PaymentSourceType::$tng);
+        $source = new RequestAlipayPlusSource();
+        $source->type = PaymentSourceType::$tng;
+        return $source;
     }
-
 }

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestBizumSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestBizumSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestBizumSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$bizum);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestBlikSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestBlikSource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestBlikSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$blik);
+    }
+
+    /**
+     * @var string
+     */
+    public $partner_agreement_id;
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestDanaSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestDanaSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestDanaSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$dana);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestGcashSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestGcashSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestGcashSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$gcash);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestKakaopaySource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestKakaopaySource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestKakaopaySource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$kakaopay);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestMobilePaySource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestMobilePaySource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestMobilePaySource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$mobilepay);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestOctopusPaySource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestOctopusPaySource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestOctopusPaySource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$octopus);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestOctopusSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestOctopusSource.php
@@ -5,7 +5,7 @@ namespace Checkout\Payments\Request\Source\Apm;
 use Checkout\Common\PaymentSourceType;
 use Checkout\Payments\Request\Source\AbstractRequestSource;
 
-class RequestOctopusPaySource extends AbstractRequestSource
+class RequestOctopusSource extends AbstractRequestSource
 {
     public function __construct()
     {

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestPayNowSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestPayNowSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestPayNowSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$paynow);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestPlaidSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestPlaidSource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\AccountHolder;
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestPlaidSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$plaid);
+    }
+
+    /**
+     * @var string
+     */
+    public $token;
+
+    /**
+     * @var AccountHolder
+     */
+    public $account_holder;
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestSequraSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestSequraSource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\Address;
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestSequraSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$sequra);
+    }
+
+    /**
+     * @var Address
+     */
+    public $billing_address;
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestSwishSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestSwishSource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\AccountHolder;
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\BillingDescriptor;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestSwishSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$swish);
+    }
+
+    /**
+     * @var string values of Country
+     */
+    public $payment_country;
+
+    /**
+     * @var AccountHolder
+     */
+    public $account_holder;
+
+    /**
+     * @var BillingDescriptor
+     */
+    public $billing_descriptor;
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestTngSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestTngSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestTngSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$tng);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestTruemoneySource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestTruemoneySource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestTruemoneySource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$truemoney);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestTwintSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestTwintSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestTwintSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$twint);
+    }
+}

--- a/lib/Checkout/Payments/Request/Source/Apm/RequestVippsSource.php
+++ b/lib/Checkout/Payments/Request/Source/Apm/RequestVippsSource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Payments\Request\Source\Apm;
+
+use Checkout\Common\PaymentSourceType;
+use Checkout\Payments\Request\Source\AbstractRequestSource;
+
+class RequestVippsSource extends AbstractRequestSource
+{
+    public function __construct()
+    {
+        parent::__construct(PaymentSourceType::$vipps);
+    }
+}

--- a/test/Checkout/Tests/Payments/Request/Source/Apm/RequestApmSourcesTest.php
+++ b/test/Checkout/Tests/Payments/Request/Source/Apm/RequestApmSourcesTest.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace Checkout\Tests\Payments\Request\Source\Apm;
+
+use Checkout\Common\AccountHolder;
+use Checkout\Common\Address;
+use Checkout\Common\PaymentSourceType;
+use Checkout\JsonSerializer;
+use Checkout\Payments\BillingDescriptor;
+use Checkout\Payments\Request\Source\Apm\RequestAchSource;
+use Checkout\Payments\Request\Source\Apm\RequestAfterPaySource;
+use Checkout\Payments\Request\Source\Apm\RequestAlipayCnSource;
+use Checkout\Payments\Request\Source\Apm\RequestAlipayHkSource;
+use Checkout\Payments\Request\Source\Apm\RequestAlipayPlusSource;
+use Checkout\Payments\Request\Source\Apm\RequestAlmaSource;
+use Checkout\Payments\Request\Source\Apm\RequestBancontactSource;
+use Checkout\Payments\Request\Source\Apm\RequestBenefitSource;
+use Checkout\Payments\Request\Source\Apm\RequestBizumSource;
+use Checkout\Payments\Request\Source\Apm\RequestBlikSource;
+use Checkout\Payments\Request\Source\Apm\RequestCvConnectSource;
+use Checkout\Payments\Request\Source\Apm\RequestDanaSource;
+use Checkout\Payments\Request\Source\Apm\RequestEpsSource;
+use Checkout\Payments\Request\Source\Apm\RequestFawrySource;
+use Checkout\Payments\Request\Source\Apm\RequestGcashSource;
+use Checkout\Payments\Request\Source\Apm\RequestGiropaySource;
+use Checkout\Payments\Request\Source\Apm\RequestIdealSource;
+use Checkout\Payments\Request\Source\Apm\RequestIllicadoSource;
+use Checkout\Payments\Request\Source\Apm\RequestKakaopaySource;
+use Checkout\Payments\Request\Source\Apm\RequestKlarnaSource;
+use Checkout\Payments\Request\Source\Apm\RequestKnetSource;
+use Checkout\Payments\Request\Source\Apm\RequestMbwaySource;
+use Checkout\Payments\Request\Source\Apm\RequestMobilePaySource;
+use Checkout\Payments\Request\Source\Apm\RequestMultiBancoSource;
+use Checkout\Payments\Request\Source\Apm\RequestOctopusPaySource;
+use Checkout\Payments\Request\Source\Apm\RequestP24Source;
+use Checkout\Payments\Request\Source\Apm\RequestPayNowSource;
+use Checkout\Payments\Request\Source\Apm\RequestPayPalSource;
+use Checkout\Payments\Request\Source\Apm\RequestPlaidSource;
+use Checkout\Payments\Request\Source\Apm\RequestPostFinanceSource;
+use Checkout\Payments\Request\Source\Apm\RequestQPaySource;
+use Checkout\Payments\Request\Source\Apm\RequestSepaSource;
+use Checkout\Payments\Request\Source\Apm\RequestSequraSource;
+use Checkout\Payments\Request\Source\Apm\RequestSofortSource;
+use Checkout\Payments\Request\Source\Apm\RequestStcPaySource;
+use Checkout\Payments\Request\Source\Apm\RequestSwishSource;
+use Checkout\Payments\Request\Source\Apm\RequestTamaraSource;
+use Checkout\Payments\Request\Source\Apm\RequestTngSource;
+use Checkout\Payments\Request\Source\Apm\RequestTruemoneySource;
+use Checkout\Payments\Request\Source\Apm\RequestTrustlySource;
+use Checkout\Payments\Request\Source\Apm\RequestTwintSource;
+use Checkout\Payments\Request\Source\Apm\RequestVippsSource;
+use Checkout\Payments\Request\Source\Apm\RequestWeChatPaySource;
+use PHPUnit\Framework\TestCase;
+
+class RequestApmSourcesTest extends TestCase
+{
+    /**
+     * Every APM source whose constructor takes no arguments.
+     * Format: 'caseName' => [fqcn, expected discriminator type, isNew]
+     *
+     * `RequestAlipayPlusSource` is excluded here because it uses static factory
+     * methods rather than a parameterless constructor; it is covered separately.
+     *
+     * @return array
+     */
+    public function apmSourceProvider()
+    {
+        return [
+            'afterpay'    => [RequestAfterPaySource::class,    PaymentSourceType::$afterpay,    false],
+            'alma'        => [RequestAlmaSource::class,        PaymentSourceType::$alma,        false],
+            'bancontact'  => [RequestBancontactSource::class,  PaymentSourceType::$bancontact,  false],
+            'benefit'     => [RequestBenefitSource::class,     PaymentSourceType::$benefit,     false],
+            'cvconnect'   => [RequestCvConnectSource::class,   PaymentSourceType::$cvconnect,   false],
+            'eps'         => [RequestEpsSource::class,         PaymentSourceType::$eps,         false],
+            'fawry'       => [RequestFawrySource::class,       PaymentSourceType::$fawry,       false],
+            'giropay'     => [RequestGiropaySource::class,     PaymentSourceType::$giropay,     false],
+            'ideal'       => [RequestIdealSource::class,       PaymentSourceType::$ideal,       false],
+            'illicado'    => [RequestIllicadoSource::class,    PaymentSourceType::$illicado,    false],
+            'klarna'      => [RequestKlarnaSource::class,      PaymentSourceType::$klarna,      false],
+            'knet'        => [RequestKnetSource::class,        PaymentSourceType::$knet,        false],
+            'mbway'       => [RequestMbwaySource::class,       PaymentSourceType::$mbway,       false],
+            'multibanco'  => [RequestMultiBancoSource::class,  PaymentSourceType::$multibanco,  false],
+            'p24'         => [RequestP24Source::class,         PaymentSourceType::$przelewy24,  false],
+            'paypal'      => [RequestPayPalSource::class,      PaymentSourceType::$paypal,      false],
+            'postfinance' => [RequestPostFinanceSource::class, PaymentSourceType::$postfinance, false],
+            'qpay'        => [RequestQPaySource::class,        PaymentSourceType::$qpay,        false],
+            'sepa'        => [RequestSepaSource::class,        PaymentSourceType::$sepa,        false],
+            'sofort'      => [RequestSofortSource::class,      PaymentSourceType::$sofort,      false],
+            'stcpay'      => [RequestStcPaySource::class,      PaymentSourceType::$stcpay,      false],
+            'tamara'      => [RequestTamaraSource::class,      PaymentSourceType::$tamara,      false],
+            'trustly'     => [RequestTrustlySource::class,     PaymentSourceType::$trustly,     false],
+            'wechatpay'   => [RequestWeChatPaySource::class,   PaymentSourceType::$wechatpay,   false],
+            'ach'         => [RequestAchSource::class,         PaymentSourceType::$ach,         true],
+            'alipay_cn'   => [RequestAlipayCnSource::class,    PaymentSourceType::$alipay_cn,   true],
+            'alipay_hk'   => [RequestAlipayHkSource::class,    PaymentSourceType::$alipay_hk,   true],
+            'bizum'       => [RequestBizumSource::class,       PaymentSourceType::$bizum,       true],
+            'blik'        => [RequestBlikSource::class,        PaymentSourceType::$blik,        true],
+            'dana'        => [RequestDanaSource::class,        PaymentSourceType::$dana,        true],
+            'gcash'       => [RequestGcashSource::class,       PaymentSourceType::$gcash,       true],
+            'kakaopay'    => [RequestKakaopaySource::class,    PaymentSourceType::$kakaopay,    true],
+            'mobilepay'   => [RequestMobilePaySource::class,   PaymentSourceType::$mobilepay,   true],
+            'octopus'     => [RequestOctopusPaySource::class,  PaymentSourceType::$octopus,     true],
+            'paynow'      => [RequestPayNowSource::class,      PaymentSourceType::$paynow,      true],
+            'plaid'       => [RequestPlaidSource::class,       PaymentSourceType::$plaid,       true],
+            'sequra'      => [RequestSequraSource::class,      PaymentSourceType::$sequra,      true],
+            'swish'       => [RequestSwishSource::class,       PaymentSourceType::$swish,       true],
+            'tng'         => [RequestTngSource::class,         PaymentSourceType::$tng,         true],
+            'truemoney'   => [RequestTruemoneySource::class,   PaymentSourceType::$truemoney,   true],
+            'twint'       => [RequestTwintSource::class,       PaymentSourceType::$twint,       true],
+            'vipps'       => [RequestVippsSource::class,       PaymentSourceType::$vipps,       true],
+        ];
+    }
+
+    /**
+     * @dataProvider apmSourceProvider
+     */
+    public function testConstructorSetsDiscriminatorType($fqcn, $expectedType)
+    {
+        $source = new $fqcn();
+
+        $this->assertTrue(property_exists($source, 'type'), "$fqcn must expose a public \$type property");
+        $this->assertSame($expectedType, $source->type);
+    }
+
+    /**
+     * @dataProvider apmSourceProvider
+     */
+    public function testMinimalPayloadSerializesWithOnlyType($fqcn, $expectedType)
+    {
+        $source = new $fqcn();
+        $json = (new JsonSerializer())->serialize($source);
+        $decoded = json_decode($json, true);
+
+        $this->assertTrue(is_array($decoded), "JSON output should decode to an array, got: $json");
+        $this->assertSame($expectedType, $decoded['type']);
+        $this->assertCount(
+            1,
+            $decoded,
+            "Minimal payload for '$fqcn' must contain only the type discriminator, got: $json"
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public function alipayPlusFactoryProvider()
+    {
+        return [
+            'alipay_plus' => ['requestAlipayPlusSource',          PaymentSourceType::$alipay_plus],
+            'alipay_cn'   => ['requestAlipayPlusCNSource',        PaymentSourceType::$alipay_cn],
+            'gcash'       => ['requestAlipayPlusGCashSource',     PaymentSourceType::$gcash],
+            'alipay_hk'   => ['requestAlipayPlusHKSource',        PaymentSourceType::$alipay_hk],
+            'dana'        => ['requestAlipayPlusDanaSource',      PaymentSourceType::$dana],
+            'kakaopay'    => ['requestAlipayPlusKakaoPaySource',  PaymentSourceType::$kakaopay],
+            'truemoney'   => ['requestAlipayPlusTrueMoneySource', PaymentSourceType::$truemoney],
+            'tng'         => ['requestAlipayPlusTNGSource',       PaymentSourceType::$tng],
+        ];
+    }
+
+    /**
+     * @dataProvider alipayPlusFactoryProvider
+     */
+    public function testAlipayPlusFactoriesProduceCorrectDiscriminator($factoryMethod, $expectedType)
+    {
+        $source = RequestAlipayPlusSource::{$factoryMethod}();
+
+        $this->assertInstanceOf(RequestAlipayPlusSource::class, $source);
+        $this->assertSame($expectedType, $source->type);
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+        $this->assertSame($expectedType, $decoded['type']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Field-level tests for sources with non-trivial structures
+    // -------------------------------------------------------------------------
+
+    public function testAchSourceSerializesAllFields()
+    {
+        $accountHolder = new AccountHolder();
+        $accountHolder->first_name = 'John';
+        $accountHolder->last_name = 'Smith';
+
+        $source = new RequestAchSource();
+        $source->account_type = 'savings';
+        $source->country = 'US';
+        $source->account_number = '136549956';
+        $source->bank_code = '021000021';
+        $source->account_holder = $accountHolder;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $this->assertSame('ach', $decoded['type']);
+        $this->assertSame('savings', $decoded['account_type']);
+        $this->assertSame('US', $decoded['country']);
+        $this->assertSame('136549956', $decoded['account_number']);
+        $this->assertSame('021000021', $decoded['bank_code']);
+        $this->assertSame(['first_name' => 'John', 'last_name' => 'Smith'], $decoded['account_holder']);
+    }
+
+    public function testBlikSourceSerializesPartnerAgreementId()
+    {
+        $source = new RequestBlikSource();
+        $source->partner_agreement_id = 'blik_payid_123456789';
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $this->assertSame('blik', $decoded['type']);
+        $this->assertSame('blik_payid_123456789', $decoded['partner_agreement_id']);
+    }
+
+    public function testPlaidSourceSerializesTokenAndAccountHolder()
+    {
+        $accountHolder = new AccountHolder();
+        $accountHolder->first_name = 'Jane';
+        $accountHolder->last_name = 'Doe';
+
+        $source = new RequestPlaidSource();
+        $source->token = 'processor-sandbox-abc123';
+        $source->account_holder = $accountHolder;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $this->assertSame('plaid', $decoded['type']);
+        $this->assertSame('processor-sandbox-abc123', $decoded['token']);
+        $this->assertSame(['first_name' => 'Jane', 'last_name' => 'Doe'], $decoded['account_holder']);
+    }
+
+    public function testSequraSourceSerializesBillingAddress()
+    {
+        $address = new Address();
+        $address->address_line1 = 'Calle Mayor 1';
+        $address->city = 'Madrid';
+        $address->state = 'Madrid';
+        $address->zip = '28001';
+        $address->country = 'ES';
+
+        $source = new RequestSequraSource();
+        $source->billing_address = $address;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $this->assertSame('sequra', $decoded['type']);
+        $this->assertSame('Calle Mayor 1', $decoded['billing_address']['address_line1']);
+        $this->assertSame('Madrid', $decoded['billing_address']['city']);
+        $this->assertSame('Madrid', $decoded['billing_address']['state']);
+        $this->assertSame('28001', $decoded['billing_address']['zip']);
+        $this->assertSame('ES', $decoded['billing_address']['country']);
+    }
+
+    public function testSwishSourceSerializesAccountHolderAndBillingDescriptor()
+    {
+        $accountHolder = new AccountHolder();
+        $accountHolder->first_name = 'Anna';
+        $accountHolder->last_name = 'Andersson';
+
+        $billingDescriptor = new BillingDescriptor();
+        $billingDescriptor->name = 'Swish Test';
+
+        $source = new RequestSwishSource();
+        $source->payment_country = 'SE';
+        $source->account_holder = $accountHolder;
+        $source->billing_descriptor = $billingDescriptor;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $this->assertSame('swish', $decoded['type']);
+        $this->assertSame('SE', $decoded['payment_country']);
+        $this->assertSame(['first_name' => 'Anna', 'last_name' => 'Andersson'], $decoded['account_holder']);
+        $this->assertSame(['name' => 'Swish Test'], $decoded['billing_descriptor']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Field-level tests for representative existing sources
+    // -------------------------------------------------------------------------
+
+    public function testSepaSourceSerializesAllFields()
+    {
+        $accountHolder = new AccountHolder();
+        $accountHolder->first_name = 'Marie';
+        $accountHolder->last_name = 'Curie';
+
+        $source = new RequestSepaSource();
+        $source->country = 'DE';
+        $source->account_number = 'DE89370400440532013000';
+        $source->bank_code = 'COBADEFFXXX';
+        $source->currency = 'EUR';
+        $source->mandate_id = 'mandate-123';
+        $source->date_of_signature = '2026-01-01';
+        $source->account_holder = $accountHolder;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $this->assertSame('sepa', $decoded['type']);
+        $this->assertSame('DE', $decoded['country']);
+        $this->assertSame('DE89370400440532013000', $decoded['account_number']);
+        $this->assertSame('COBADEFFXXX', $decoded['bank_code']);
+        $this->assertSame('EUR', $decoded['currency']);
+        $this->assertSame('mandate-123', $decoded['mandate_id']);
+        $this->assertSame('2026-01-01', $decoded['date_of_signature']);
+        $this->assertSame(['first_name' => 'Marie', 'last_name' => 'Curie'], $decoded['account_holder']);
+    }
+
+    public function testQPaySourceSerializesAllFields()
+    {
+        $source = new RequestQPaySource();
+        $source->quantity = 1;
+        $source->description = 'QPay test payment';
+        $source->language = 'en';
+        $source->national_id = 'ID-12345';
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $this->assertSame('qpay', $decoded['type']);
+        $this->assertSame(1, $decoded['quantity']);
+        $this->assertSame('QPay test payment', $decoded['description']);
+        $this->assertSame('en', $decoded['language']);
+        $this->assertSame('ID-12345', $decoded['national_id']);
+    }
+
+    public function testAlmaSourceSerializesBillingAddress()
+    {
+        $address = new Address();
+        $address->address_line1 = '12 rue de Paris';
+        $address->city = 'Paris';
+        $address->country = 'FR';
+
+        $source = new RequestAlmaSource();
+        $source->billing_address = $address;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $this->assertSame('alma', $decoded['type']);
+        $this->assertSame('12 rue de Paris', $decoded['billing_address']['address_line1']);
+        $this->assertSame('Paris', $decoded['billing_address']['city']);
+        $this->assertSame('FR', $decoded['billing_address']['country']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Catch-all enum check
+    // -------------------------------------------------------------------------
+
+    public function testEnumConstantsExposeAllNewTypes()
+    {
+        $this->assertSame('ach', PaymentSourceType::$ach);
+        $this->assertSame('bizum', PaymentSourceType::$bizum);
+        $this->assertSame('blik', PaymentSourceType::$blik);
+        $this->assertSame('mobilepay', PaymentSourceType::$mobilepay);
+        $this->assertSame('octopus', PaymentSourceType::$octopus);
+        $this->assertSame('paynow', PaymentSourceType::$paynow);
+        $this->assertSame('plaid', PaymentSourceType::$plaid);
+        $this->assertSame('sequra', PaymentSourceType::$sequra);
+        $this->assertSame('swish', PaymentSourceType::$swish);
+        $this->assertSame('twint', PaymentSourceType::$twint);
+        $this->assertSame('vipps', PaymentSourceType::$vipps);
+    }
+}

--- a/test/Checkout/Tests/Payments/Request/Source/Apm/RequestApmSourcesTest.php
+++ b/test/Checkout/Tests/Payments/Request/Source/Apm/RequestApmSourcesTest.php
@@ -3,6 +3,9 @@
 namespace Checkout\Tests\Payments\Request\Source\Apm;
 
 use Checkout\Common\AccountHolder;
+use Checkout\Common\AccountHolderAch;
+use Checkout\Common\AccountHolderIdentification;
+use Checkout\Common\AccountHolderType;
 use Checkout\Common\Address;
 use Checkout\Common\PaymentSourceType;
 use Checkout\JsonSerializer;
@@ -31,7 +34,7 @@ use Checkout\Payments\Request\Source\Apm\RequestKnetSource;
 use Checkout\Payments\Request\Source\Apm\RequestMbwaySource;
 use Checkout\Payments\Request\Source\Apm\RequestMobilePaySource;
 use Checkout\Payments\Request\Source\Apm\RequestMultiBancoSource;
-use Checkout\Payments\Request\Source\Apm\RequestOctopusPaySource;
+use Checkout\Payments\Request\Source\Apm\RequestOctopusSource;
 use Checkout\Payments\Request\Source\Apm\RequestP24Source;
 use Checkout\Payments\Request\Source\Apm\RequestPayNowSource;
 use Checkout\Payments\Request\Source\Apm\RequestPayPalSource;
@@ -57,9 +60,6 @@ class RequestApmSourcesTest extends TestCase
     /**
      * Every APM source whose constructor takes no arguments.
      * Format: 'caseName' => [fqcn, expected discriminator type, isNew]
-     *
-     * `RequestAlipayPlusSource` is excluded here because it uses static factory
-     * methods rather than a parameterless constructor; it is covered separately.
      *
      * @return array
      */
@@ -90,6 +90,7 @@ class RequestApmSourcesTest extends TestCase
             'tamara'      => [RequestTamaraSource::class,      PaymentSourceType::$tamara,      false],
             'trustly'     => [RequestTrustlySource::class,     PaymentSourceType::$trustly,     false],
             'wechatpay'   => [RequestWeChatPaySource::class,   PaymentSourceType::$wechatpay,   false],
+            'alipay_plus' => [RequestAlipayPlusSource::class,  PaymentSourceType::$alipay_plus, false],
             'ach'         => [RequestAchSource::class,         PaymentSourceType::$ach,         true],
             'alipay_cn'   => [RequestAlipayCnSource::class,    PaymentSourceType::$alipay_cn,   true],
             'alipay_hk'   => [RequestAlipayHkSource::class,    PaymentSourceType::$alipay_hk,   true],
@@ -99,7 +100,7 @@ class RequestApmSourcesTest extends TestCase
             'gcash'       => [RequestGcashSource::class,       PaymentSourceType::$gcash,       true],
             'kakaopay'    => [RequestKakaopaySource::class,    PaymentSourceType::$kakaopay,    true],
             'mobilepay'   => [RequestMobilePaySource::class,   PaymentSourceType::$mobilepay,   true],
-            'octopus'     => [RequestOctopusPaySource::class,  PaymentSourceType::$octopus,     true],
+            'octopus'     => [RequestOctopusSource::class,  PaymentSourceType::$octopus,     true],
             'paynow'      => [RequestPayNowSource::class,      PaymentSourceType::$paynow,      true],
             'plaid'       => [RequestPlaidSource::class,       PaymentSourceType::$plaid,       true],
             'sequra'      => [RequestSequraSource::class,      PaymentSourceType::$sequra,      true],
@@ -141,9 +142,14 @@ class RequestApmSourcesTest extends TestCase
     }
 
     /**
+     * Static factories on RequestAlipayPlusSource are kept for backwards compatibility
+     * but are deprecated in favour of the dedicated source classes (or, for `alipay_plus`,
+     * the parameterless constructor). This provider keeps regression coverage so we
+     * notice if a future change silently breaks the deprecated path before removal.
+     *
      * @return array<string, array{0: string, 1: string}>
      */
-    public function alipayPlusFactoryProvider()
+    public function deprecatedAlipayPlusFactoryProvider()
     {
         return [
             'alipay_plus' => ['requestAlipayPlusSource',          PaymentSourceType::$alipay_plus],
@@ -158,9 +164,9 @@ class RequestApmSourcesTest extends TestCase
     }
 
     /**
-     * @dataProvider alipayPlusFactoryProvider
+     * @dataProvider deprecatedAlipayPlusFactoryProvider
      */
-    public function testAlipayPlusFactoriesProduceCorrectDiscriminator($factoryMethod, $expectedType)
+    public function testDeprecatedAlipayPlusFactoriesStillProduceCorrectDiscriminator($factoryMethod, $expectedType)
     {
         $source = RequestAlipayPlusSource::{$factoryMethod}();
 
@@ -177,7 +183,8 @@ class RequestApmSourcesTest extends TestCase
 
     public function testAchSourceSerializesAllFields()
     {
-        $accountHolder = new AccountHolder();
+        $accountHolder = new AccountHolderAch();
+        $accountHolder->type = AccountHolderType::$individual;
         $accountHolder->first_name = 'John';
         $accountHolder->last_name = 'Smith';
 
@@ -195,7 +202,58 @@ class RequestApmSourcesTest extends TestCase
         $this->assertSame('US', $decoded['country']);
         $this->assertSame('136549956', $decoded['account_number']);
         $this->assertSame('021000021', $decoded['bank_code']);
-        $this->assertSame(['first_name' => 'John', 'last_name' => 'Smith'], $decoded['account_holder']);
+        $this->assertSame(
+            ['type' => 'individual', 'first_name' => 'John', 'last_name' => 'Smith'],
+            $decoded['account_holder']
+        );
+    }
+
+    public function testAchSourceSerializesFullAccountHolderAchSchema()
+    {
+        $billingAddress = new Address();
+        $billingAddress->address_line1 = '90 Tottenham Court Road';
+        $billingAddress->city = 'London';
+        $billingAddress->country = 'GB';
+
+        $identification = new AccountHolderIdentification();
+        $identification->type = 'SSN';
+        $identification->number = '123-45-6789';
+        $identification->issuing_country = 'US';
+
+        $accountHolder = new AccountHolderAch();
+        $accountHolder->type = AccountHolderType::$corporate;
+        $accountHolder->first_name = 'Jane';
+        $accountHolder->last_name = 'Doe';
+        $accountHolder->company_name = 'Acme Co.';
+        $accountHolder->billing_address = $billingAddress;
+        $accountHolder->date_of_birth = '1985-04-12';
+        $accountHolder->identification = $identification;
+
+        $source = new RequestAchSource();
+        $source->account_holder = $accountHolder;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($source), true);
+
+        $expected = [
+            'type' => 'corporate',
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+            'company_name' => 'Acme Co.',
+            'billing_address' => [
+                'address_line1' => '90 Tottenham Court Road',
+                'city' => 'London',
+                'country' => 'GB',
+            ],
+            'date_of_birth' => '1985-04-12',
+            'identification' => [
+                'type' => 'SSN',
+                'number' => '123-45-6789',
+                'issuing_country' => 'US',
+            ],
+        ];
+
+        $this->assertSame('ach', $decoded['type']);
+        $this->assertSame($expected, $decoded['account_holder']);
     }
 
     public function testBlikSourceSerializesPartnerAgreementId()

--- a/test/Checkout/Tests/Payments/RequestApmPaymentsIntegrationTest.php
+++ b/test/Checkout/Tests/Payments/RequestApmPaymentsIntegrationTest.php
@@ -40,7 +40,7 @@ use Checkout\Payments\Request\Source\Apm\RequestTrustlySource;
 use Checkout\Payments\Request\Source\Apm\RequestAfterPaySource;
 use Checkout\Payments\Request\Source\Apm\RequestIllicadoSource;
 use Checkout\Payments\Request\Source\Apm\RequestCvConnectSource;
-use Checkout\Payments\Request\Source\Apm\RequestAlipayPlusSource;
+use Checkout\Payments\Request\Source\Apm\RequestAlipayCnSource;
 use Checkout\Payments\Request\Source\Apm\RequestBancontactSource;
 use Checkout\Payments\Request\Source\Apm\RequestMultiBancoSource;
 use Checkout\Payments\Request\Source\Apm\RequestPostFinanceSource;
@@ -53,7 +53,7 @@ class RequestApmPaymentsIntegrationTest extends AbstractPaymentsIntegrationTest
      */
     public function shouldMakeAliPayPayment()
     {
-        $requestSource = RequestAlipayPlusSource::requestAlipayPlusCNSource();
+        $requestSource = new RequestAlipayCnSource();
 
         $paymentRequest = new PaymentRequest();
         $paymentRequest->reference = $this->randomEmail();


### PR DESCRIPTION
This pull request adds support for a wide range of new alternative payment methods (APMs) by introducing new payment source types and corresponding request source classes. These changes enable the system to handle additional payment options such as ACH, Bizum, Blik, MobilePay, Octopus, PayNow, Plaid, Sequra, Swish, Twint, and Vipps, among others. The update primarily involves extending the `PaymentSourceType` enumeration and implementing new request classes for each APM, some of which include additional relevant fields.

**Support for new payment source types:**

* Added new static members to `PaymentSourceType` for various APMs, including `bizum`, `ach`, `blik`, `mobilepay`, `octopus`, `paynow`, `plaid`, `sequra`, `swish`, `twint`, and `vipps`.

**New request source classes for APMs:**

* Implemented new request source classes in the `Apm` namespace for each supported APM:
  - `RequestAchSource`, `RequestBizumSource`, `RequestBlikSource`, `RequestMobilePaySource`, `RequestOctopusPaySource`, `RequestPayNowSource`, `RequestPlaidSource`, `RequestSequraSource`, `RequestSwishSource`, `RequestTwintSource`, `RequestVippsSource`, and others. [[1]](diffhunk://#diff-dec0e331ef1980b03eaa751897de43102373343ad1007da459495aabbaee8ddbR1-R40) [[2]](diffhunk://#diff-e5f33497d2ff41fe375dbe8fc66992dfcaadae66642cd7ce143118b618cdc43bR1-R14) [[3]](diffhunk://#diff-22ebd445c4e840c15ff6ee350491dc5f8105edfbf3a1c17c244f8426e50207d4R1-R19) [[4]](diffhunk://#diff-5958a281e7fd99ea5c3d2c8eb88bd70e49aee495df3e2c766a561171963581ddR1-R14) [[5]](diffhunk://#diff-9a46d5b388015a55a99b2e07cb0099726c8739b1285f89eefdd831a478dd64f5R1-R14) [[6]](diffhunk://#diff-d0caf6bec7f55a5cb47b41ea276407aab2ca2a00e37355ae65159ba41534f6beR1-R14) [[7]](diffhunk://#diff-88af6195ce98397555dfda2fd4da07205fbfd715705d6bc5dbdf236b433de5a0R1-R25) [[8]](diffhunk://#diff-c2412b05a5b2c58692b5bee08fbc852d68101e07e30b5cc0bf06777de4aa5cecR1-R20) [[9]](diffhunk://#diff-5cd0a78a82d614a5cab796bbfcc67c3143f55cf4c4ae7998aff2a1cdaaf03651R1-R31) [[10]](diffhunk://#diff-f0fe68f7155511696b748f42f35df69c44535461bb4135d0611a9fb8a15e50e9R1-R14) [[11]](diffhunk://#diff-cb69234d22eb239c3751afa944f025063e3610c8ddfe5dbbf01f97052bcf82ddR1-R14)

**Additional fields for specific payment sources:**

* Some new request source classes include additional fields relevant to their payment method, such as `account_type`, `country`, `account_number` for ACH, `partner_agreement_id` for Blik, `token` and `account_holder` for Plaid, `billing_address` for Sequra, and `billing_descriptor` for Swish. [[1]](diffhunk://#diff-dec0e331ef1980b03eaa751897de43102373343ad1007da459495aabbaee8ddbR1-R40) [[2]](diffhunk://#diff-22ebd445c4e840c15ff6ee350491dc5f8105edfbf3a1c17c244f8426e50207d4R1-R19) [[3]](diffhunk://#diff-88af6195ce98397555dfda2fd4da07205fbfd715705d6bc5dbdf236b433de5a0R1-R25) [[4]](diffhunk://#diff-c2412b05a5b2c58692b5bee08fbc852d68101e07e30b5cc0bf06777de4aa5cecR1-R20) [[5]](diffhunk://#diff-5cd0a78a82d614a5cab796bbfcc67c3143f55cf4c4ae7998aff2a1cdaaf03651R1-R31)

These changes collectively expand the system's capability to support a broader array of payment methods, improving flexibility and coverage for international payments.