### PR TITLE
Some comments updated + more tests

### DIFF
--- a/lib/Checkout/AgenticCommerce/Entities/DelegatedPaymentAllowance.php
+++ b/lib/Checkout/AgenticCommerce/Entities/DelegatedPaymentAllowance.php
@@ -36,7 +36,7 @@ class DelegatedPaymentAllowance
     /**
      * The unique identifier of the merchant that will process the payment.
      * [Required]
-     * Length: <= 256 characters
+     * Length: max 256 characters
      *
      * @var string
      */

--- a/lib/Checkout/AgenticCommerce/Entities/DelegatedPaymentBillingAddress.php
+++ b/lib/Checkout/AgenticCommerce/Entities/DelegatedPaymentBillingAddress.php
@@ -10,7 +10,7 @@ class DelegatedPaymentBillingAddress
     /**
      * The full name of the customer.
      * [Required]
-     * Length: <= 256 characters
+     * Length: max 256 characters
      *
      * @var string
      */
@@ -19,7 +19,7 @@ class DelegatedPaymentBillingAddress
     /**
      * The first line of the street address.
      * [Required]
-     * Length: <= 60 characters
+     * Length: max 60 characters
      *
      * @var string
      */
@@ -28,7 +28,7 @@ class DelegatedPaymentBillingAddress
     /**
      * The second line of the street address.
      * [Optional]
-     * Length: <= 60 characters
+     * Length: max 60 characters
      *
      * @var string|null
      */
@@ -37,7 +37,7 @@ class DelegatedPaymentBillingAddress
     /**
      * The city of the billing address.
      * [Required]
-     * Length: <= 60 characters
+     * Length: max 60 characters
      *
      * @var string
      */
@@ -54,7 +54,7 @@ class DelegatedPaymentBillingAddress
     /**
      * The postal code or ZIP code of the billing address.
      * [Required]
-     * Length: <= 20 characters
+     * Length: max 20 characters
      *
      * @var string
      */

--- a/lib/Checkout/Issuing/Cardholders/CardholderRequest.php
+++ b/lib/Checkout/Issuing/Cardholders/CardholderRequest.php
@@ -17,7 +17,7 @@ class CardholderRequest
     /**
      * Your reference.
      * [Optional]
-     * <= 256 characters
+     * max 256 characters
      * @var string
      */
     public $reference;

--- a/lib/Checkout/Issuing/Cards/Create/CardRequest.php
+++ b/lib/Checkout/Issuing/Cards/Create/CardRequest.php
@@ -35,7 +35,7 @@ abstract class CardRequest
     /**
      * Your reference.
      * [Optional]
-     * <= 256 characters
+     * max 256 characters
      * @var string
      */
     public $reference;

--- a/lib/Checkout/Issuing/Cards/Update/UpdateCardRequest.php
+++ b/lib/Checkout/Issuing/Cards/Update/UpdateCardRequest.php
@@ -9,7 +9,7 @@ class UpdateCardRequest
     /**
      * Your reference.
      * [Optional]
-     * <= 256 characters
+     * max 256 characters
      * @var string
      */
     public $reference;
@@ -24,8 +24,8 @@ class UpdateCardRequest
     /**
      * The card's expiration month.
      * [Optional]
-     * >= 1
-     * <= 12
+     * min 1
+     * max 12
      * @var int
      */
     public $expiry_month;

--- a/lib/Checkout/Issuing/Disputes/Requests/AmendDisputeRequest.php
+++ b/lib/Checkout/Issuing/Disputes/Requests/AmendDisputeRequest.php
@@ -44,7 +44,7 @@ class AmendDisputeRequest
      * team and may be submitted to the card scheme.
      * This field is required if you change the reason at the escalation stage.
      * [Optional]
-     * <= 13000 characters
+     * max 13000 characters
      * @var string
      */
     public $reason_change_justification;
@@ -53,7 +53,7 @@ class AmendDisputeRequest
      * Free-form text that you can use to explain your choices, provide additional context, or ask questions
      * about the requested changes.
      * [Optional]
-     * <= 1000 characters
+     * max 1000 characters
      * @var string
      */
     public $action_response;

--- a/lib/Checkout/Issuing/Disputes/Requests/CreateDisputeRequest.php
+++ b/lib/Checkout/Issuing/Disputes/Requests/CreateDisputeRequest.php
@@ -62,7 +62,7 @@ class CreateDisputeRequest
     /**
      * Short justification for raising this dispute, to be sent to the scheme.
      * [Optional]
-     * <= 100 characters
+     * max 100 characters
      * @var string
      */
     public $justification;

--- a/lib/Checkout/Issuing/Disputes/Requests/EscalateDisputeRequest.php
+++ b/lib/Checkout/Issuing/Disputes/Requests/EscalateDisputeRequest.php
@@ -11,7 +11,7 @@ class EscalateDisputeRequest
     /**
      * Justification for escalating the dispute.
      * [Required]
-     * <= 13000 characters
+     * max 13000 characters
      * @var string
      */
     public $justification;

--- a/lib/Checkout/Payments/Setups/Common/BillingDescriptor/PaymentSetupBillingDescriptor.php
+++ b/lib/Checkout/Payments/Setups/Common/BillingDescriptor/PaymentSetupBillingDescriptor.php
@@ -7,7 +7,7 @@ class PaymentSetupBillingDescriptor
     /**
      * A dynamic description of the payment.
      * [Optional]
-     * <= 25 characters
+     * max 25 characters
      * @var string
      */
     public $name;
@@ -15,7 +15,7 @@ class PaymentSetupBillingDescriptor
     /**
      * The city from which the payment was made.
      * [Optional]
-     * <= 13 characters
+     * max 13 characters
      * @var string
      */
     public $city;
@@ -23,7 +23,7 @@ class PaymentSetupBillingDescriptor
     /**
      * The reference shown on the statement.
      * [Optional]
-     * <= 50 characters
+     * max 50 characters
      * @var string
      */
     public $reference;

--- a/lib/Checkout/Payments/Setups/Common/Order/AmountAllocationCommission.php
+++ b/lib/Checkout/Payments/Setups/Common/Order/AmountAllocationCommission.php
@@ -7,7 +7,7 @@ class AmountAllocationCommission
     /**
      * Optional fixed amount of commission to collect, in the minor currency unit.
      * [Optional]
-     * >= 0
+     * min 0
      * @var int
      */
     public $amount;
@@ -15,8 +15,8 @@ class AmountAllocationCommission
     /**
      * Optional percentage of commission to collect.
      * [Optional]
-     * >= 0
-     * <= 100
+     * min 0
+     * max 100
      * @var float
      */
     public $percentage;

--- a/lib/Checkout/Payments/Setups/Common/Order/Order.php
+++ b/lib/Checkout/Payments/Setups/Common/Order/Order.php
@@ -30,7 +30,7 @@ class Order
     /**
      * The discount amount applied to the order.
      * [Optional]
-     * >= 0
+     * min 0
      * @var int
      */
     public $discount_amount;
@@ -45,7 +45,7 @@ class Order
     /**
      * The total shipping amount for the order.
      * [Optional]
-     * >= 0
+     * min 0
      * @var int
      */
     public $shipping_amount;
@@ -53,7 +53,7 @@ class Order
     /**
      * The total surcharge amount for the order.
      * [Optional]
-     * >= 0
+     * min 0
      * @var int
      */
     public $surcharge_amount;
@@ -61,7 +61,7 @@ class Order
     /**
      * The total tax amount for the order.
      * [Optional]
-     * >= 0
+     * min 0
      * @var int
      */
     public $tax_amount;
@@ -69,7 +69,7 @@ class Order
     /**
      * The total tipping amount for the order.
      * [Optional]
-     * >= 0
+     * min 0
      * @var int
      */
     public $tipping_amount;

--- a/lib/Checkout/Payments/Setups/Common/Order/PaymentSetupAmountAllocation.php
+++ b/lib/Checkout/Payments/Setups/Common/Order/PaymentSetupAmountAllocation.php
@@ -15,8 +15,8 @@ class PaymentSetupAmountAllocation
      * The split amount - this will be credited to your sub-entity's currency account. The sum of all split
      * amounts must be equal to the payment amount. Provided in the minor currency unit.
      * [Required]
-     * >= 0
-     * <= 9999999999
+     * min 0
+     * max 9999999999
      * @var int
      */
     public $amount;
@@ -24,7 +24,7 @@ class PaymentSetupAmountAllocation
     /**
      * A reference you can later use to identify this split, such as an order number.
      * [Optional]
-     * <= 50 characters
+     * max 50 characters
      * @var string
      */
     public $reference;

--- a/lib/Checkout/Payments/Setups/Request/PaymentSetupRequest.php
+++ b/lib/Checkout/Payments/Setups/Request/PaymentSetupRequest.php
@@ -45,7 +45,7 @@ class PaymentSetupRequest
     /**
      * A reference you can use to identify the payment. For example, an order number.
      * [Optional]
-     * <= 80 characters
+     * max 80 characters
      * @var string
      */
     public $reference;
@@ -53,7 +53,7 @@ class PaymentSetupRequest
     /**
      * A description of the payment.
      * [Optional]
-     * <= 100 characters
+     * max 100 characters
      * @var string
      */
     public $description;

--- a/test/Checkout/Tests/Accounts/InstrumentDetailsAchSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/InstrumentDetailsAchSerializationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\InstrumentAccountType;
+use Checkout\Accounts\InstrumentDetailsAch;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class InstrumentDetailsAchSerializationTest extends TestCase
+{
+    public function testInstrumentDetailsAchRoundTrip()
+    {
+        $details = new InstrumentDetailsAch();
+        $details->account_number = "0123456789";
+        $details->routing_number = "021000021";
+        $details->account_type = InstrumentAccountType::$checking;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($details), true);
+
+        $this->assertSame("0123456789", $decoded['account_number']);
+        $this->assertSame("021000021", $decoded['routing_number']);
+        $this->assertSame("checking", $decoded['account_type']);
+    }
+
+    public function testAccountTypeSerializesToExactSwaggerValues()
+    {
+        $savings = new InstrumentDetailsAch();
+        $savings->account_type = InstrumentAccountType::$savings;
+        $decodedSavings = json_decode((new JsonSerializer())->serialize($savings), true);
+        $this->assertSame("savings", $decodedSavings['account_type']);
+
+        $checking = new InstrumentDetailsAch();
+        $checking->account_type = InstrumentAccountType::$checking;
+        $decodedChecking = json_decode((new JsonSerializer())->serialize($checking), true);
+        $this->assertSame("checking", $decodedChecking['account_type']);
+    }
+}

--- a/test/Checkout/Tests/Issuing/Disputes/DisputeRequestsSerializationTest.php
+++ b/test/Checkout/Tests/Issuing/Disputes/DisputeRequestsSerializationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Checkout\Tests\Issuing\Disputes;
+
+use Checkout\Issuing\Disputes\Entities\Evidence;
+use Checkout\Issuing\Disputes\Entities\IssuingDisputeFraudDetails;
+use Checkout\Issuing\Disputes\Entities\IssuingDisputeFraudType;
+use Checkout\Issuing\Disputes\Requests\AmendDisputeRequest;
+use Checkout\Issuing\Disputes\Requests\CreateDisputeRequest;
+use Checkout\Issuing\Disputes\Requests\EscalateDisputeRequest;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class DisputeRequestsSerializationTest extends TestCase
+{
+    private function fraudDetails()
+    {
+        $fraudDetails = new IssuingDisputeFraudDetails();
+        $fraudDetails->fraud_type = IssuingDisputeFraudType::$card_stolen;
+        $fraudDetails->description = "Card reported stolen";
+        return $fraudDetails;
+    }
+
+    public function testAmendDisputeRequestRoundTrip()
+    {
+        $evidence = new Evidence();
+        $evidence->name = "evidence.pdf";
+        $evidence->content = "base64content";
+        $evidence->description = "Supporting document";
+
+        $request = new AmendDisputeRequest();
+        $request->reason = "4853";
+        $request->amount = 1000;
+        $request->evidence = [$evidence];
+        $request->fraud_details = $this->fraudDetails();
+        $request->reason_change_justification = "Updated reason after review";
+        $request->action_response = "Additional context provided";
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame("4853", $decoded['reason']);
+        $this->assertSame(1000, $decoded['amount']);
+        $this->assertSame("evidence.pdf", $decoded['evidence'][0]['name']);
+        $this->assertSame("base64content", $decoded['evidence'][0]['content']);
+        $this->assertSame("card_stolen", $decoded['fraud_details']['fraud_type']);
+        $this->assertSame("Card reported stolen", $decoded['fraud_details']['description']);
+        $this->assertSame("Updated reason after review", $decoded['reason_change_justification']);
+        $this->assertSame("Additional context provided", $decoded['action_response']);
+    }
+
+    public function testCreateDisputeRequestSerializesFraudDetails()
+    {
+        $request = new CreateDisputeRequest();
+        $request->transaction_id = "trx_00000000000000000000000000";
+        $request->reason = "10.4";
+        $request->fraud_details = $this->fraudDetails();
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame("card_stolen", $decoded['fraud_details']['fraud_type']);
+        $this->assertSame("Card reported stolen", $decoded['fraud_details']['description']);
+    }
+
+    public function testEscalateDisputeRequestSerializesFraudDetails()
+    {
+        $request = new EscalateDisputeRequest();
+        $request->justification = "Escalating after new evidence";
+        $request->fraud_details = $this->fraudDetails();
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame("card_stolen", $decoded['fraud_details']['fraud_type']);
+    }
+
+    /**
+     * @dataProvider fraudTypeProvider
+     */
+    public function testFraudTypeSerializesToExactSwaggerValue($property, $expected)
+    {
+        $fraudDetails = new IssuingDisputeFraudDetails();
+        $fraudDetails->fraud_type = IssuingDisputeFraudType::${$property};
+
+        $decoded = json_decode((new JsonSerializer())->serialize($fraudDetails), true);
+
+        $this->assertSame($expected, $decoded['fraud_type']);
+    }
+
+    public function fraudTypeProvider()
+    {
+        return [
+            ["card_lost", "card_lost"],
+            ["card_stolen", "card_stolen"],
+            ["card_never_received", "card_never_received"],
+            ["fraudulent_account", "fraudulent_account"],
+            ["counterfeit_card", "counterfeit_card"],
+            ["account_takeover", "account_takeover"],
+            ["card_not_present_fraud", "card_not_present_fraud"],
+            ["merchant_misrepresentation", "merchant_misrepresentation"],
+            ["cardholder_manipulation", "cardholder_manipulation"],
+            ["incorrect_processing", "incorrect_processing"],
+            ["other", "other"],
+        ];
+    }
+}

--- a/test/Checkout/Tests/Payments/Setups/PaymentSetupFieldsSerializationTest.php
+++ b/test/Checkout/Tests/Payments/Setups/PaymentSetupFieldsSerializationTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Checkout\Tests\Payments\Setups;
+
+use Checkout\JsonSerializer;
+use Checkout\Payments\Setups\Common\BillingDescriptor\PaymentSetupBillingDescriptor;
+use Checkout\Payments\Setups\Common\Order\AmountAllocationCommission;
+use Checkout\Payments\Setups\Common\Order\Order;
+use Checkout\Payments\Setups\Common\Order\PaymentSetupAmountAllocation;
+use Checkout\Payments\Setups\Common\PaymentMethods\Bacs\Bacs;
+use Checkout\Payments\Setups\Common\PaymentMethods\Bacs\BacsAccountHolder;
+use Checkout\Payments\Setups\Common\PaymentMethods\Bacs\BacsAccountHolderType;
+use Checkout\Payments\Setups\Common\PaymentMethods\CardPresent\CardPresent;
+use Checkout\Payments\Setups\Common\PaymentMethods\PayByBank\PayByBank;
+use Checkout\Payments\Setups\Common\PaymentMethods\PaymentMethods;
+use Checkout\Payments\Setups\Common\PaymentMethods\Stablecoin\Stablecoin;
+use Checkout\Payments\Setups\Common\PresentmentDetails\PaymentSetupPresentmentDetails;
+use Checkout\Payments\Setups\Common\Terminal\PaymentSetupTerminal;
+use Checkout\Payments\Setups\Request\PaymentSetupRequest;
+use PHPUnit\Framework\TestCase;
+
+class PaymentSetupFieldsSerializationTest extends TestCase
+{
+    public function testSerializesBillingDescriptorPresentmentDetailsAndTerminal()
+    {
+        $request = new PaymentSetupRequest();
+
+        $request->billing_descriptor = new PaymentSetupBillingDescriptor();
+        $request->billing_descriptor->name = "Checkout.com";
+        $request->billing_descriptor->city = "London";
+        $request->billing_descriptor->reference = "ref_123";
+
+        $request->presentment_details = new PaymentSetupPresentmentDetails();
+        $request->presentment_details->amount = 110;
+        $request->presentment_details->currency = "GBP";
+
+        $request->terminal = new PaymentSetupTerminal();
+        $request->terminal->id = "12345678";
+        $request->terminal->local_date_time = "2026-06-01T10:00:00Z";
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame("Checkout.com", $decoded['billing_descriptor']['name']);
+        $this->assertSame("London", $decoded['billing_descriptor']['city']);
+        $this->assertSame("ref_123", $decoded['billing_descriptor']['reference']);
+
+        $this->assertSame(110, $decoded['presentment_details']['amount']);
+        $this->assertSame("GBP", $decoded['presentment_details']['currency']);
+
+        $this->assertSame("12345678", $decoded['terminal']['id']);
+        $this->assertSame("2026-06-01T10:00:00Z", $decoded['terminal']['local_date_time']);
+    }
+
+    public function testSerializesNewPaymentMethodConfigs()
+    {
+        $bacs = new Bacs();
+        $bacs->instrument_id = "src_test";
+        $bacs->account_number = "12345678";
+        $bacs->bank_code = "050389";
+        $bacs->country = "GB";
+        $bacs->currency = "GBP";
+        $bacs->allow_partial_match = true;
+        $bacs->account_holder = new BacsAccountHolder();
+        $bacs->account_holder->type = BacsAccountHolderType::$individual;
+        $bacs->account_holder->first_name = "John";
+
+        $cardPresent = new CardPresent();
+        $cardPresent->entry_mode = "chip";
+        $cardPresent->store_for_future_use = true;
+
+        $payByBank = new PayByBank();
+        $payByBank->bank_id = "bank_123";
+
+        $paymentMethods = new PaymentMethods();
+        $paymentMethods->bacs = $bacs;
+        $paymentMethods->card_present = $cardPresent;
+        $paymentMethods->pay_by_bank = $payByBank;
+        $paymentMethods->stablecoin = new Stablecoin();
+
+        $request = new PaymentSetupRequest();
+        $request->payment_methods = $paymentMethods;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame("src_test", $decoded['payment_methods']['bacs']['instrument_id']);
+        $this->assertSame("050389", $decoded['payment_methods']['bacs']['bank_code']);
+        $this->assertSame("GB", $decoded['payment_methods']['bacs']['country']);
+        $this->assertTrue($decoded['payment_methods']['bacs']['allow_partial_match']);
+        $this->assertSame("individual", $decoded['payment_methods']['bacs']['account_holder']['type']);
+        $this->assertSame("John", $decoded['payment_methods']['bacs']['account_holder']['first_name']);
+
+        $this->assertSame("chip", $decoded['payment_methods']['card_present']['entry_mode']);
+        $this->assertTrue($decoded['payment_methods']['card_present']['store_for_future_use']);
+
+        $this->assertSame("bank_123", $decoded['payment_methods']['pay_by_bank']['bank_id']);
+
+        $this->assertArrayHasKey('stablecoin', $decoded['payment_methods']);
+    }
+
+    public function testSerializesOrderAmountAllocationsAndScalars()
+    {
+        $commission = new AmountAllocationCommission();
+        $commission->amount = 100;
+        $commission->percentage = 1.5;
+
+        $allocation = new PaymentSetupAmountAllocation();
+        $allocation->id = "ent_test";
+        $allocation->amount = 1000;
+        $allocation->reference = "order_123";
+        $allocation->commission = $commission;
+
+        $order = new Order();
+        $order->amount_allocations = [$allocation];
+        $order->invoice_id = "inv_123";
+        $order->shipping_amount = 50;
+        $order->surcharge_amount = 10;
+        $order->tax_amount = 200;
+        $order->tipping_amount = 100;
+
+        $request = new PaymentSetupRequest();
+        $request->order = $order;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $allocationJson = $decoded['order']['amount_allocations'][0];
+        $this->assertSame("ent_test", $allocationJson['id']);
+        $this->assertSame(1000, $allocationJson['amount']);
+        $this->assertSame("order_123", $allocationJson['reference']);
+        $this->assertSame(100, $allocationJson['commission']['amount']);
+        $this->assertSame(1.5, $allocationJson['commission']['percentage']);
+
+        $this->assertSame("inv_123", $decoded['order']['invoice_id']);
+        $this->assertSame(50, $decoded['order']['shipping_amount']);
+        $this->assertSame(10, $decoded['order']['surcharge_amount']);
+        $this->assertSame(200, $decoded['order']['tax_amount']);
+        $this->assertSame(100, $decoded['order']['tipping_amount']);
+    }
+
+    public function testUnsetFieldsAreOmittedFromSerialization()
+    {
+        $decoded = json_decode((new JsonSerializer())->serialize(new PaymentSetupRequest()), true);
+
+        $this->assertArrayNotHasKey('billing_descriptor', $decoded);
+        $this->assertArrayNotHasKey('presentment_details', $decoded);
+        $this->assertArrayNotHasKey('terminal', $decoded);
+    }
+}


### PR DESCRIPTION
This pull request standardizes the documentation for property constraints across multiple entity classes by replacing inconsistent constraint descriptions (like `<= 256 characters` or `>= 0`) with a uniform format (`max 256 characters`, `min 0`, etc.). Additionally, it introduces new unit tests to ensure correct serialization of ACH instrument details and issuing dispute requests.

Key changes include:

**Documentation consistency improvements:**

* Updated property constraint comments throughout entity classes to use a consistent format, such as `max N characters`, `min N`, and `max N`, instead of mixed inequality symbols. This affects fields for string length, numeric ranges, and other constraints in classes like `DelegatedPaymentBillingAddress`, `CardholderRequest`, `Order`, `AmountAllocationCommission`, `PaymentSetupBillingDescriptor`, `PaymentSetupRequest`, and various dispute and card request classes. [[1]](diffhunk://#diff-b5fcded2e8a85cac59d384a593ad7376bef3216091cb29de1999e7f4ab4d2bb3L39-R39) [[2]](diffhunk://#diff-0e578735f8d1a6c7e7b3c24db1d678304aac1eb1b8d2f58e799f05fd544c1240L13-R13) [[3]](diffhunk://#diff-0e578735f8d1a6c7e7b3c24db1d678304aac1eb1b8d2f58e799f05fd544c1240L22-R22) [[4]](diffhunk://#diff-0e578735f8d1a6c7e7b3c24db1d678304aac1eb1b8d2f58e799f05fd544c1240L31-R31) [[5]](diffhunk://#diff-0e578735f8d1a6c7e7b3c24db1d678304aac1eb1b8d2f58e799f05fd544c1240L40-R40) [[6]](diffhunk://#diff-0e578735f8d1a6c7e7b3c24db1d678304aac1eb1b8d2f58e799f05fd544c1240L57-R57) [[7]](diffhunk://#diff-5821ff4f7abb424fa2409968c8c51e74320a32707d64f211f4af9a17f5e0048aL20-R20) [[8]](diffhunk://#diff-ea2dd09233f7e1adf3be6878018cc7c27df21f75b1d18075e068e977ef4dd928L38-R38) [[9]](diffhunk://#diff-738956bb46cb81b22d63ca05438880839930a0b8bc85264b80fd9987506a5fd2L12-R12) [[10]](diffhunk://#diff-738956bb46cb81b22d63ca05438880839930a0b8bc85264b80fd9987506a5fd2L27-R28) [[11]](diffhunk://#diff-9b4d6013fb9697ecf1d33723ffe07c69341d88c366237692445ffbef1d0c2c6dL47-R47) [[12]](diffhunk://#diff-9b4d6013fb9697ecf1d33723ffe07c69341d88c366237692445ffbef1d0c2c6dL56-R56) [[13]](diffhunk://#diff-50fff86db7e364c991084bdaf484c67265f44af43a16fc849e80d607335715bbL65-R65) [[14]](diffhunk://#diff-0135725da32636fe9215862183703a47fe70ce23cbd980ad81484ed390ae2873L14-R14) [[15]](diffhunk://#diff-530668bb06bdf2ea702c7f485f00ea35b92032a641a2544593e7a29746afcff2L10-R26) [[16]](diffhunk://#diff-6ce7212ca74b03bcc556a51e43693b75065681bb806aa0612564d4eb6ae0e299L10-R19) [[17]](diffhunk://#diff-39670825c2ee982b2bf78eaafa6fa2cdda043b2cae46ae741504d004fb8879adL33-R33) [[18]](diffhunk://#diff-39670825c2ee982b2bf78eaafa6fa2cdda043b2cae46ae741504d004fb8879adL48-R72) [[19]](diffhunk://#diff-c3973b52d515f450ec5c6688f297b05a9a9dc5f95aad22950360d35839d2ceb8L18-R27) [[20]](diffhunk://#diff-bac9192404d75b6e249f4c55b81757d1a0711d25492f299242d4f72efa4935baL48-R56)

**Testing improvements:**

* Added `InstrumentDetailsAchSerializationTest.php` to verify round-trip serialization and correct Swagger value output for ACH instrument account types.
* Added `DisputeRequestsSerializationTest.php` to test serialization of dispute request objects, including fraud details and evidence, and to ensure fraud type values map exactly to Swagger definitions.