### PR TITLE
8.4 version fix

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -66,7 +66,7 @@ jobs:
                   # Download PHP based on version
                   switch ($phpVersion) {
                       "8.1" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-8.1.34-Win32-vs16-x64.zip" }
-                      "8.4" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-8.4.21-Win32-vs17-x64.zip" }
+                      "8.4" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-8.4.23-Win32-vs17-x64.zip" }
                       default { throw "Unsupported PHP version: $phpVersion" }
                   }
                   


### PR DESCRIPTION
This pull request updates and fixes the PHP 8.4 download URL in the build workflow to use the latest patch version. This ensures that builds use the most recent and secure release of PHP 8.4.

- Updated the PHP 8.4 download URL in `.github/workflows/build-master.yml` from version `8.4.21` to `8.4.23` to ensure the workflow uses the latest available patch version.