### PR TITLE
feature/INT-1655 - Support for negotiating Accounts API schema version via the `Accept` header

### DIFF
--- a/lib/Checkout/Accounts/AccountsClient.php
+++ b/lib/Checkout/Accounts/AccountsClient.php
@@ -25,6 +25,11 @@ class AccountsClient extends Client
     const RESERVE_RULES_PATH = "reserve-rules";
     const REQUIREMENTS_PATH = "requirements";
 
+    /**
+     * The latest Accounts API schema version, negotiated through the Accept header.
+     */
+    const DEFAULT_SCHEMA_VERSION = "3.0";
+
     private $filesApiClient;
 
     public function __construct(
@@ -37,16 +42,32 @@ class AccountsClient extends Client
     }
 
     /**
+     * Build the Accept header used to negotiate the Accounts API schema version.
+     *
+     * @param string $schemaVersion
+     * @return Headers
+     */
+    private function buildSchemaVersionHeaders($schemaVersion)
+    {
+        $headers = new Headers();
+        $headers->accept = "application/json;schema_version=" . $schemaVersion;
+        return $headers;
+    }
+
+    /**
      * @param OnboardEntityRequest $entityRequest
+     * @param string $schemaVersion The Accounts API schema version to request (default: latest, 3.0)
      * @return array
      * @throws CheckoutApiException
      */
-    public function createEntity(OnboardEntityRequest $entityRequest)
+    public function createEntity(OnboardEntityRequest $entityRequest, $schemaVersion = self::DEFAULT_SCHEMA_VERSION)
     {
         return $this->apiClient->post(
             $this->buildPath(self::ACCOUNTS_PATH, self::ENTITIES_PATH),
             $entityRequest,
-            $this->sdkAuthorization()
+            $this->sdkAuthorization(),
+            null,
+            $this->buildSchemaVersionHeaders($schemaVersion)
         );
     }
 
@@ -66,29 +87,36 @@ class AccountsClient extends Client
 
     /**
      * @param $entityId
+     * @param string $schemaVersion The Accounts API schema version to request (default: latest, 3.0)
      * @return array
      * @throws CheckoutApiException
      */
-    public function getEntity($entityId)
+    public function getEntity($entityId, $schemaVersion = self::DEFAULT_SCHEMA_VERSION)
     {
         return $this->apiClient->get(
             $this->buildPath(self::ACCOUNTS_PATH, self::ENTITIES_PATH, $entityId),
-            $this->sdkAuthorization()
+            $this->sdkAuthorization(),
+            $this->buildSchemaVersionHeaders($schemaVersion)
         );
     }
 
     /**
      * @param $entityId
      * @param OnboardEntityRequest $entityRequest
+     * @param string $schemaVersion The Accounts API schema version to request (default: latest, 3.0)
      * @return array
      * @throws CheckoutApiException
      */
-    public function updateEntity($entityId, OnboardEntityRequest $entityRequest)
-    {
+    public function updateEntity(
+        $entityId,
+        OnboardEntityRequest $entityRequest,
+        $schemaVersion = self::DEFAULT_SCHEMA_VERSION
+    ) {
         return $this->apiClient->put(
             $this->buildPath(self::ACCOUNTS_PATH, self::ENTITIES_PATH, $entityId),
             $entityRequest,
-            $this->sdkAuthorization()
+            $this->sdkAuthorization(),
+            $this->buildSchemaVersionHeaders($schemaVersion)
         );
     }
 
@@ -361,14 +389,16 @@ class AccountsClient extends Client
      * Retrieve the list of pending requirements for a sub-entity.
      *
      * @param string $entityId The sub-entity's ID (Required)
+     * @param string $schemaVersion The Accounts API schema version to request (default: latest, 3.0)
      * @return array
      * @throws CheckoutApiException
      */
-    public function getEntityRequirements($entityId)
+    public function getEntityRequirements($entityId, $schemaVersion = self::DEFAULT_SCHEMA_VERSION)
     {
         return $this->apiClient->get(
             $this->buildPath(self::ACCOUNTS_PATH, self::ENTITIES_PATH, $entityId, self::REQUIREMENTS_PATH),
-            $this->sdkAuthorization()
+            $this->sdkAuthorization(),
+            $this->buildSchemaVersionHeaders($schemaVersion)
         );
     }
 

--- a/lib/Checkout/Accounts/AgreedTerms.php
+++ b/lib/Checkout/Accounts/AgreedTerms.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class AgreedTerms
+{
+    /**
+     * @var string the date the terms were agreed, in ISO 8601 format
+     */
+    public $date;
+
+    /**
+     * @var string the IP address from which the terms were agreed
+     */
+    public $ip_address;
+
+    /**
+     * @var string the name of the person who agreed to the terms
+     */
+    public $name;
+
+    /**
+     * @var string the email of the person who agreed to the terms
+     */
+    public $email;
+
+    /**
+     * @var string the version of the terms that were agreed
+     */
+    public $version;
+}

--- a/lib/Checkout/Accounts/AgreedTerms.php
+++ b/lib/Checkout/Accounts/AgreedTerms.php
@@ -2,30 +2,50 @@
 
 namespace Checkout\Accounts;
 
+/**
+ * The terms of service the sub-entity agreed to (Accounts API v3.0, SaaS onboarding).
+ */
 class AgreedTerms
 {
     /**
-     * @var string the date the terms were agreed, in ISO 8601 format
+     * The date and time the terms were agreed.
+     * [Required]
+     * Format: date-time (RFC 3339)
+     *
+     * @var string
      */
     public $date;
 
     /**
-     * @var string the IP address from which the terms were agreed
+     * The IP address from which the terms were agreed.
+     * [Required]
+     *
+     * @var string
      */
     public $ip_address;
 
     /**
-     * @var string the name of the person who agreed to the terms
+     * The name of the person who agreed to the terms.
+     * [Required]
+     *
+     * @var string
      */
     public $name;
 
     /**
-     * @var string the email of the person who agreed to the terms
+     * The email address of the person who agreed to the terms.
+     * [Required]
+     * Format: email
+     *
+     * @var string
      */
     public $email;
 
     /**
-     * @var string the version of the terms that were agreed
+     * The version of the terms that were agreed.
+     * [Required]
+     *
+     * @var string
      */
     public $version;
 }

--- a/lib/Checkout/Accounts/BusinessType.php
+++ b/lib/Checkout/Accounts/BusinessType.php
@@ -4,11 +4,23 @@ namespace Checkout\Accounts;
 
 class BusinessType
 {
+    public static $individual_or_sole_proprietorship = "individual_or_sole_proprietorship";
     public static $general_partnership = "general_partnership";
     public static $limited_partnership = "limited_partnership";
+    public static $scottish_limited_partnership = "scottish_limited_partnership";
     public static $public_limited_company = "public_limited_company";
     public static $limited_company = "limited_company";
+    public static $limited_liability_corporation = "limited_liability_corporation";
+    public static $private_corporation = "private_corporation";
+    public static $publicly_traded_corporation = "publicly_traded_corporation";
     public static $professional_association = "professional_association";
     public static $unincorporated_association = "unincorporated_association";
     public static $auto_entrepreneur = "auto_entrepreneur";
+    public static $government_agency = "government_agency";
+    public static $non_profit_entity = "non_profit_entity";
+    public static $trust = "trust";
+    public static $club_or_society = "club_or_society";
+    public static $regulated_financial_institution = "regulated_financial_institution";
+    public static $cftc_registered_entity = "cftc_registered_entity";
+    public static $sec_registered_entity = "sec_registered_entity";
 }

--- a/lib/Checkout/Accounts/Company.php
+++ b/lib/Checkout/Accounts/Company.php
@@ -27,6 +27,21 @@ class Company
     public $trading_name;
 
     /**
+     * @var array of string additional names the company trades under (v3.0)
+     */
+    public $additional_trading_names;
+
+    /**
+     * @var bool whether the entity is a registered company (v3.0)
+     */
+    public $is_registered_company;
+
+    /**
+     * @var DateOfIncorporation the date the company was incorporated (v3.0)
+     */
+    public $date_of_incorporation;
+
+    /**
      * @var Address
      */
     public $principal_address;

--- a/lib/Checkout/Accounts/Company.php
+++ b/lib/Checkout/Accounts/Company.php
@@ -4,64 +4,112 @@ namespace Checkout\Accounts;
 
 use Checkout\Common\Address;
 
+/**
+ * Information about the company represented by a sub-entity.
+ * Which fields are required depends on the sub-entity's region and onboarding variant.
+ */
 class Company
 {
     /**
+     * The company's registration number.
+     * [Required]
+     * Format: region-specific (validated by the API against the sub-entity's country)
+     *
      * @var string
      */
     public $business_registration_number;
 
     /**
+     * The company's business type.
+     * [Required]
+     * Enum: "individual_or_sole_proprietorship", "limited_company", "public_limited_company",
+     * "limited_partnership", "general_partnership", "scottish_limited_partnership",
+     * "government_agency", "non_profit_entity", "trust", "club_or_society",
+     * "unincorporated_association"
+     *
      * @var string value of BusinessType
      */
     public $business_type;
 
     /**
+     * The company's registered legal name.
+     * [Required]
+     * Length: 2 to 300 characters
+     *
      * @var string
      */
     public $legal_name;
 
     /**
+     * The name the company trades under.
+     * [Required]
+     * Length: 2 to 300 characters
+     *
      * @var string
      */
     public $trading_name;
 
     /**
-     * @var array of string additional names the company trades under (v3.0)
+     * Additional names the company trades under.
+     * [Optional]
+     * Format: array of string (Accounts API v3.0)
+     *
+     * @var array of string
      */
     public $additional_trading_names;
 
     /**
-     * @var bool whether the entity is a registered company (v3.0)
+     * Indicates whether the sub-entity is a registered legal entity.
+     * [Optional] (Accounts API v3.0)
+     *
+     * @var bool
      */
     public $is_registered_company;
 
     /**
-     * @var DateOfIncorporation the date the company was incorporated (v3.0)
+     * The date the company was incorporated.
+     * [Required] for the full onboarding variants (Accounts API v3.0)
+     *
+     * @var DateOfIncorporation
      */
     public $date_of_incorporation;
 
     /**
+     * The company's principal (place of business) address.
+     * [Required]
+     *
      * @var Address
      */
     public $principal_address;
 
     /**
+     * The company's registered address.
+     * [Required]
+     *
      * @var Address
      */
     public $registered_address;
 
     /**
+     * A company verification document.
+     * [Optional]
+     *
      * @var EntityDocument
      */
     public $document;
 
     /**
+     * The company's representatives (persons of interest).
+     * [Required]
+     *
      * @var array of Representative
      */
     public $representatives;
 
     /**
+     * The company's financial details.
+     * [Optional]
+     *
      * @var EntityFinancialDetails
      */
     public $financial_details;

--- a/lib/Checkout/Accounts/Company.php
+++ b/lib/Checkout/Accounts/Company.php
@@ -67,6 +67,15 @@ class Company
     public $is_registered_company;
 
     /**
+     * The regulatory licence number of the company.
+     * [Optional]
+     * Length: max 32 characters
+     *
+     * @var string
+     */
+    public $regulatory_licence_number;
+
+    /**
      * The date the company was incorporated.
      * [Required] for the full onboarding variants (Accounts API v3.0)
      *

--- a/lib/Checkout/Accounts/CompanyPosition.php
+++ b/lib/Checkout/Accounts/CompanyPosition.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class CompanyPosition
+{
+    public static $ceo = "ceo";
+    public static $cfo = "cfo";
+    public static $coo = "coo";
+    public static $managing_member = "managing_member";
+    public static $general_partner = "general_partner";
+    public static $president = "president";
+    public static $vice_president = "vice_president";
+    public static $treasurer = "treasurer";
+    public static $other_senior_management = "other_senior_management";
+    public static $other_executive_officer = "other_executive_officer";
+    public static $other_non_executive_non_senior = "other_non_executive_non_senior";
+}

--- a/lib/Checkout/Accounts/DateOfIncorporation.php
+++ b/lib/Checkout/Accounts/DateOfIncorporation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class DateOfIncorporation
+{
+    /**
+     * @var int the day of the month the company was incorporated
+     */
+    public $day;
+
+    /**
+     * @var int the month the company was incorporated
+     */
+    public $month;
+
+    /**
+     * @var int the year the company was incorporated
+     */
+    public $year;
+}

--- a/lib/Checkout/Accounts/DateOfIncorporation.php
+++ b/lib/Checkout/Accounts/DateOfIncorporation.php
@@ -2,20 +2,35 @@
 
 namespace Checkout\Accounts;
 
+/**
+ * The date a company was incorporated (Accounts API v3.0).
+ */
 class DateOfIncorporation
 {
     /**
-     * @var int the day of the month the company was incorporated
+     * The day of the month the company was incorporated.
+     * [Optional]
+     * Range: 1 to 31
+     *
+     * @var int
      */
     public $day;
 
     /**
-     * @var int the month the company was incorporated
+     * The month the company was incorporated.
+     * [Required]
+     * Range: 1 to 12
+     *
+     * @var int
      */
     public $month;
 
     /**
-     * @var int the year the company was incorporated
+     * The year the company was incorporated.
+     * [Required]
+     * Range: 1500 to 2999
+     *
+     * @var int
      */
     public $year;
 }

--- a/lib/Checkout/Accounts/EntityRoles.php
+++ b/lib/Checkout/Accounts/EntityRoles.php
@@ -6,4 +6,7 @@ class EntityRoles
 {
     public static $ubo = "ubo";
     public static $legal_representative = "legal_representative";
+    public static $authorised_signatory = "authorised_signatory";
+    public static $director = "director";
+    public static $control_person = "control_person";
 }

--- a/lib/Checkout/Accounts/Headers.php
+++ b/lib/Checkout/Accounts/Headers.php
@@ -5,7 +5,18 @@ namespace Checkout\Accounts;
 class Headers
 {
     /**
+     * Value for the If-Match header, used to identify a specific version of a
+     * reserve rule to update (for example "Y3Y9MCZydj0w"). Etag.
+     *
      * @var string
      */
     public $if_match;
+
+    /**
+     * Value for the Accept header, used to negotiate the Accounts API schema version
+     * (for example "application/json;schema_version=3.0").
+     *
+     * @var string
+     */
+    public $accept;
 }

--- a/lib/Checkout/Accounts/OnboardEntityRequest.php
+++ b/lib/Checkout/Accounts/OnboardEntityRequest.php
@@ -82,4 +82,12 @@ class OnboardEntityRequest
      * @var string
      */
     public $seller_category;
+
+    /**
+     * Specifies whether the sub-entity details are in draft.
+     * [Optional]
+     *
+     * @var bool
+     */
+    public $is_draft;
 }

--- a/lib/Checkout/Accounts/OnboardEntityRequest.php
+++ b/lib/Checkout/Accounts/OnboardEntityRequest.php
@@ -26,6 +26,7 @@ class OnboardEntityRequest
 
     /**
      * @var Individual
+     * @deprecated Not used by the Accounts API v3.0 schema; retained for v2.0 compatibility.
      */
     public $individual;
 
@@ -33,4 +34,19 @@ class OnboardEntityRequest
      * @var OnboardSubEntityDocuments
      */
     public $documents;
+
+    /**
+     * @var ProcessingDetails processing details of the sub-entity (v3.0)
+     */
+    public $processing_details;
+
+    /**
+     * @var AgreedTerms the terms the sub-entity agreed to (v3.0, SaaS onboarding)
+     */
+    public $agreed_terms;
+
+    /**
+     * @var string the identifier of a seller category configured for your platform (v3.0, SaaS onboarding)
+     */
+    public $seller_category;
 }

--- a/lib/Checkout/Accounts/OnboardEntityRequest.php
+++ b/lib/Checkout/Accounts/OnboardEntityRequest.php
@@ -2,51 +2,84 @@
 
 namespace Checkout\Accounts;
 
+/**
+ * Request to onboard a sub-entity. Which fields are required depends on the sub-entity's region
+ * and onboarding variant (see the Accounts API onboarding schema variants).
+ */
 class OnboardEntityRequest
 {
     /**
+     * A unique reference you can later use to identify the sub-entity.
+     * [Required]
+     * Length: 1 to 50 characters
+     *
      * @var string
      */
     public $reference;
 
     /**
+     * Contact details of the sub-entity.
+     * [Required]
+     *
      * @var ContactDetails
      */
     public $contact_details;
 
     /**
+     * Information about the profile of the sub-entity.
+     * [Required]
+     *
      * @var Profile
      */
     public $profile;
 
     /**
+     * Information about the company represented by the sub-entity.
+     * [Required] for company and sole trader sub-entities (Accounts API v3.0)
+     *
      * @var Company
      */
     public $company;
 
     /**
+     * Information about the individual represented by the sub-entity.
+     * [Optional]
+     * Deprecated: not used by the Accounts API v3.0 schema; retained for v2.0 compatibility.
+     *
      * @var Individual
-     * @deprecated Not used by the Accounts API v3.0 schema; retained for v2.0 compatibility.
+     * @deprecated Use {@link Company} (with representatives) for the Accounts API v3.0 schema.
      */
     public $individual;
 
     /**
+     * The verification documents for the sub-entity.
+     * [Optional] (required for the full onboarding variants)
+     *
      * @var OnboardSubEntityDocuments
      */
     public $documents;
 
     /**
-     * @var ProcessingDetails processing details of the sub-entity (v3.0)
+     * Information about the sub-entity's expected processing.
+     * [Required] (Accounts API v3.0)
+     *
+     * @var ProcessingDetails
      */
     public $processing_details;
 
     /**
-     * @var AgreedTerms the terms the sub-entity agreed to (v3.0, SaaS onboarding)
+     * Details of the person who agreed to the terms and conditions.
+     * [Optional] (required for the SaaS onboarding variants, Accounts API v3.0)
+     *
+     * @var AgreedTerms
      */
     public $agreed_terms;
 
     /**
-     * @var string the identifier of a seller category configured for your platform (v3.0, SaaS onboarding)
+     * The identifier of a seller category configured for your platform.
+     * [Optional] (required for the SaaS onboarding variants, Accounts API v3.0)
+     *
+     * @var string
      */
     public $seller_category;
 }

--- a/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
+++ b/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
@@ -18,4 +18,44 @@ class OnboardSubEntityDocuments
      * @var TaxVerification
      */
     public $tax_verification;
+
+    /**
+     * @var Document articles of association (v3.0)
+     */
+    public $articles_of_association;
+
+    /**
+     * @var Document shareholder structure document (v3.0)
+     */
+    public $shareholder_structure;
+
+    /**
+     * @var Document bank verification document (v3.0)
+     */
+    public $bank_verification;
+
+    /**
+     * @var Document proof of principal address (v3.0)
+     */
+    public $proof_of_principal_address;
+
+    /**
+     * @var Document proof of legality (v3.0)
+     */
+    public $proof_of_legality;
+
+    /**
+     * @var Document additional supporting document (v3.0)
+     */
+    public $additional_document1;
+
+    /**
+     * @var Document additional supporting document (v3.0)
+     */
+    public $additional_document2;
+
+    /**
+     * @var Document additional supporting document (v3.0)
+     */
+    public $additional_document3;
 }

--- a/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
+++ b/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
@@ -65,6 +65,14 @@ class OnboardSubEntityDocuments
     public $financial_statements;
 
     /**
+     * Financial verification document.
+     * [Optional]
+     *
+     * @var Document
+     */
+    public $financial_verification;
+
+    /**
      * Proof of principal address document.
      * [Optional]
      *

--- a/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
+++ b/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
@@ -2,60 +2,105 @@
 
 namespace Checkout\Accounts;
 
+/**
+ * The documents supplied to onboard a sub-entity. Which documents are required depends on the
+ * sub-entity's region and business type (see the Accounts API onboarding schema variants).
+ */
 class OnboardSubEntityDocuments
 {
     /**
+     * Identity verification document.
+     * [Optional]
+     *
      * @var Document
      */
     public $identity_verification;
 
     /**
+     * Company verification document.
+     * [Optional]
+     *
      * @var CompanyVerification
      */
     public $company_verification;
 
     /**
+     * Tax verification document.
+     * [Optional]
+     *
      * @var TaxVerification
      */
     public $tax_verification;
 
     /**
-     * @var Document articles of association (v3.0)
+     * Articles of association document.
+     * [Optional] (required for the company full onboarding variants)
+     *
+     * @var Document
      */
     public $articles_of_association;
 
     /**
-     * @var Document shareholder structure document (v3.0)
+     * Shareholder structure document.
+     * [Optional] (required for the company full onboarding variants)
+     *
+     * @var Document
      */
     public $shareholder_structure;
 
     /**
-     * @var Document bank verification document (v3.0)
+     * Bank verification document.
+     * [Optional] (required for the EEA company and sole trader full onboarding variants)
+     *
+     * @var Document
      */
     public $bank_verification;
 
     /**
-     * @var Document proof of principal address (v3.0)
+     * Financial statements document.
+     * [Optional]
+     *
+     * @var Document
+     */
+    public $financial_statements;
+
+    /**
+     * Proof of principal address document.
+     * [Optional]
+     *
+     * @var Document
      */
     public $proof_of_principal_address;
 
     /**
-     * @var Document proof of legality (v3.0)
+     * Proof of legality document.
+     * [Optional]
+     *
+     * @var Document
      */
     public $proof_of_legality;
 
     /**
-     * @var Document additional supporting document (v3.0)
+     * Additional supporting document.
+     * [Optional]
+     *
+     * @var Document
      */
     public $additional_document1;
 
     /**
-     * @var Document additional supporting document (v3.0)
+     * Additional supporting document.
+     * [Optional]
+     *
+     * @var Document
      */
     public $additional_document2;
 
     /**
-     * @var Document additional supporting document (v3.0)
+     * Additional supporting document.
+     * [Optional]
+     *
+     * @var Document
      */
     public $additional_document3;
 }

--- a/lib/Checkout/Accounts/ProcessingDetails.php
+++ b/lib/Checkout/Accounts/ProcessingDetails.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class ProcessingDetails
+{
+    /**
+     * @var int the estimated annual processing volume in minor units without decimals
+     */
+    public $annual_processing_volume;
+
+    /**
+     * @var int the estimated average transaction value in minor units without decimals
+     */
+    public $average_transaction_value;
+
+    /**
+     * @var int the estimated average order fulfillment time in days
+     */
+    public $average_order_fulfillment_time;
+
+    /**
+     * @var string value of Currency
+     */
+    public $currency;
+
+    /**
+     * @var array of Country the countries the sub-entity intends to sell to
+     */
+    public $target_countries;
+
+    /**
+     * @var ProcessingDetailsPayments
+     */
+    public $payments;
+}

--- a/lib/Checkout/Accounts/ProcessingDetails.php
+++ b/lib/Checkout/Accounts/ProcessingDetails.php
@@ -2,34 +2,60 @@
 
 namespace Checkout\Accounts;
 
+/**
+ * The expected payment processing details of a sub-entity (Accounts API v3.0).
+ */
 class ProcessingDetails
 {
     /**
-     * @var int the estimated annual processing volume in minor units without decimals
+     * The estimated annual processing volume, in the minor currency unit.
+     * [Required]
+     * Minimum: 0
+     *
+     * @var int
      */
     public $annual_processing_volume;
 
     /**
-     * @var int the estimated average transaction value in minor units without decimals
+     * The estimated average transaction value, in the minor currency unit.
+     * [Required]
+     * Minimum: 0
+     *
+     * @var int
      */
     public $average_transaction_value;
 
     /**
-     * @var int the estimated average order fulfillment time in days
+     * The estimated average order fulfillment time, in days.
+     * [Required]
+     * Minimum: 0
+     *
+     * @var int
      */
     public $average_order_fulfillment_time;
 
     /**
+     * The currency used for the processing details provided.
+     * [Required]
+     * Format: ISO 4217 (three-letter currency code)
+     *
      * @var string value of Currency
      */
     public $currency;
 
     /**
-     * @var array of Country the countries the sub-entity intends to sell to
+     * The countries the sub-entity intends to sell to.
+     * [Required]
+     * Format: array of ISO 3166-1 alpha-2 country codes
+     *
+     * @var array of Country
      */
     public $target_countries;
 
     /**
+     * Payment method-specific processing details.
+     * [Required]
+     *
      * @var ProcessingDetailsPayments
      */
     public $payments;

--- a/lib/Checkout/Accounts/ProcessingDetails.php
+++ b/lib/Checkout/Accounts/ProcessingDetails.php
@@ -35,6 +35,15 @@ class ProcessingDetails
     public $average_order_fulfillment_time;
 
     /**
+     * The expected highest transaction value, in the minor currency unit.
+     * [Required] for the company and sole trader full onboarding variants
+     * Minimum: 0
+     *
+     * @var int
+     */
+    public $highest_transaction_value;
+
+    /**
      * The currency used for the processing details provided.
      * [Required]
      * Format: ISO 4217 (three-letter currency code)
@@ -42,6 +51,15 @@ class ProcessingDetails
      * @var string value of Currency
      */
     public $currency;
+
+    /**
+     * The country where the settlement bank account is located.
+     * [Required] for the company and sole trader full onboarding variants
+     * Format: ISO 3166-1 alpha-2 (two-letter country code)
+     *
+     * @var string value of Country
+     */
+    public $settlement_country;
 
     /**
      * The countries the sub-entity intends to sell to.

--- a/lib/Checkout/Accounts/ProcessingDetailsAch.php
+++ b/lib/Checkout/Accounts/ProcessingDetailsAch.php
@@ -2,25 +2,44 @@
 
 namespace Checkout\Accounts;
 
+/**
+ * ACH payment processing details (Accounts API v3.0).
+ */
 class ProcessingDetailsAch
 {
     /**
-     * @var int the estimated annual ACH processing volume in minor units without decimals
+     * The estimated annual ACH processing volume, in the minor currency unit.
+     * [Required]
+     * Minimum: 0
+     *
+     * @var int
      */
     public $annual_ach_volume;
 
     /**
-     * @var int the estimated average ACH transaction size in minor units without decimals
+     * The estimated average ACH transaction size, in the minor currency unit.
+     * [Required]
+     * Minimum: 0
+     *
+     * @var int
      */
     public $average_ach_transaction_size;
 
     /**
-     * @var int the estimated monthly credit volume in minor units without decimals
+     * The estimated monthly credit volume, in the minor currency unit.
+     * [Required]
+     * Minimum: 0
+     *
+     * @var int
      */
     public $estimated_monthly_credit_volume;
 
     /**
-     * @var int the estimated average credit amount in minor units without decimals
+     * The estimated average credit amount, in the minor currency unit.
+     * [Required]
+     * Minimum: 0
+     *
+     * @var int
      */
     public $average_credit_amount;
 }

--- a/lib/Checkout/Accounts/ProcessingDetailsAch.php
+++ b/lib/Checkout/Accounts/ProcessingDetailsAch.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class ProcessingDetailsAch
+{
+    /**
+     * @var int the estimated annual ACH processing volume in minor units without decimals
+     */
+    public $annual_ach_volume;
+
+    /**
+     * @var int the estimated average ACH transaction size in minor units without decimals
+     */
+    public $average_ach_transaction_size;
+
+    /**
+     * @var int the estimated monthly credit volume in minor units without decimals
+     */
+    public $estimated_monthly_credit_volume;
+
+    /**
+     * @var int the estimated average credit amount in minor units without decimals
+     */
+    public $average_credit_amount;
+}

--- a/lib/Checkout/Accounts/ProcessingDetailsPayments.php
+++ b/lib/Checkout/Accounts/ProcessingDetailsPayments.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class ProcessingDetailsPayments
+{
+    /**
+     * @var ProcessingDetailsAch
+     */
+    public $ach;
+}

--- a/lib/Checkout/Accounts/ProcessingDetailsPayments.php
+++ b/lib/Checkout/Accounts/ProcessingDetailsPayments.php
@@ -2,9 +2,15 @@
 
 namespace Checkout\Accounts;
 
+/**
+ * Payment method-specific processing details (Accounts API v3.0).
+ */
 class ProcessingDetailsPayments
 {
     /**
+     * ACH payment processing details.
+     * [Required]
+     *
      * @var ProcessingDetailsAch
      */
     public $ach;

--- a/lib/Checkout/Accounts/Representative.php
+++ b/lib/Checkout/Accounts/Representative.php
@@ -52,7 +52,7 @@ class Representative
     /**
      * The percentage ownership of the UBO or controlling company.
      * [Optional]
-     * Range: 25 to 100
+     * Range: 0 to 100 (a minimum of 25 applies to the company full onboarding variants)
      *
      * @var int
      */

--- a/lib/Checkout/Accounts/Representative.php
+++ b/lib/Checkout/Accounts/Representative.php
@@ -5,58 +5,127 @@ namespace Checkout\Accounts;
 use Checkout\Common\Address;
 use Checkout\Common\Phone;
 
+/**
+ * A company representative ("person of interest") on the Accounts API. In the v3.0 schema the
+ * personal details are nested under {@link $individual}; the flat person fields are retained for
+ * v2.0 compatibility only.
+ */
 class Representative
 {
     /**
-     * The representative's personal details, as required by the Accounts API v3.0 schema.
+     * The representative's id.
+     * [Optional]
+     * Length: 30 characters
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The representative's personal details.
+     * [Required] (Accounts API v3.0)
      *
      * @var RepresentativeIndividual
      */
     public $individual;
 
     /**
+     * The roles the representative holds within the company.
+     * [Required] (Accounts API v3.0)
+     * Enum: "ubo", "authorised_signatory", "director", "control_person", "legal_representative"
+     *
+     * @var array values of EntityRoles
+     */
+    public $roles;
+
+    /**
+     * The position of the representative within the company.
+     * [Optional]
+     * Enum: "ceo", "cfo", "coo", "managing_member", "general_partner", "president",
+     * "vice_president", "treasurer", "other_senior_management", "other_executive_officer",
+     * "other_non_executive_non_senior"
+     *
+     * @var string value of CompanyPosition
+     */
+    public $company_position;
+
+    /**
+     * The percentage ownership of the UBO or controlling company.
+     * [Optional]
+     * Range: 25 to 100
+     *
+     * @var int
+     */
+    public $ownership_percentage;
+
+    /**
+     * The representative's verification documents.
+     * [Optional]
+     *
+     * @var OnboardSubEntityDocuments
+     */
+    public $documents;
+
+    /**
+     * The representative's first name.
+     * [Optional]
+     *
      * @var string
      * @deprecated Not used by the Accounts API v3.0 schema; use {@link $individual} instead.
      */
     public $first_name;
 
     /**
+     * The representative's last name.
+     * [Optional]
+     *
      * @var string
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link $individual} instead.
      */
     public $last_name;
 
     /**
+     * The representative's address.
+     * [Optional]
+     *
      * @var Address
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link $individual} instead.
      */
     public $address;
 
     /**
+     * The representative's identification.
+     * [Optional]
+     *
      * @var Identification
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link $individual} instead.
      */
     public $identification;
 
     /**
+     * The representative's phone number.
+     * [Optional]
+     *
      * @var Phone
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link $individual} instead.
      */
     public $phone;
 
     /**
+     * The representative's date of birth.
+     * [Optional]
+     *
      * @var DateOfBirth
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link $individual} instead.
      */
     public $date_of_birth;
 
     /**
+     * The representative's place of birth.
+     * [Optional]
+     *
      * @var PlaceOfBirth
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link $individual} instead.
      */
     public $place_of_birth;
-
-    /**
-     * @var array values of EntityRoles
-     */
-    public $roles;
-
-    /**
-     * @var OnboardSubEntityDocuments
-     */
-    public $documents;
 }

--- a/lib/Checkout/Accounts/Representative.php
+++ b/lib/Checkout/Accounts/Representative.php
@@ -8,7 +8,15 @@ use Checkout\Common\Phone;
 class Representative
 {
     /**
+     * The representative's personal details, as required by the Accounts API v3.0 schema.
+     *
+     * @var RepresentativeIndividual
+     */
+    public $individual;
+
+    /**
      * @var string
+     * @deprecated Not used by the Accounts API v3.0 schema; use {@link $individual} instead.
      */
     public $first_name;
 

--- a/lib/Checkout/Accounts/RepresentativeIndividual.php
+++ b/lib/Checkout/Accounts/RepresentativeIndividual.php
@@ -5,49 +5,85 @@ namespace Checkout\Accounts;
 use Checkout\Common\Address;
 use Checkout\Common\Phone;
 
+/**
+ * The personal details of a company representative ("person of interest"), as required by the
+ * Accounts API v3.0 schema.
+ */
 class RepresentativeIndividual
 {
     /**
+     * The representative's first name.
+     * [Required]
+     * Length: 2 to 50 characters
+     *
      * @var string
      */
     public $first_name;
 
     /**
+     * The representative's middle name. Required if it appears in official documents.
+     * [Optional]
+     * Length: 2 to 50 characters
+     *
      * @var string
      */
     public $middle_name;
 
     /**
+     * The representative's last name.
+     * [Required]
+     * Length: 2 to 50 characters
+     *
      * @var string
      */
     public $last_name;
 
     /**
+     * The representative's date of birth.
+     * [Required]
+     *
      * @var DateOfBirth
      */
     public $date_of_birth;
 
     /**
+     * The representative's place of birth.
+     * [Required]
+     *
      * @var PlaceOfBirth
      */
     public $place_of_birth;
 
     /**
+     * The representative's national identification number.
+     * [Optional]
+     * Format: region-specific (validated by the API against the sub-entity's country)
+     *
      * @var string
      */
     public $national_id_number;
 
     /**
+     * The representative's email address.
+     * [Optional]
+     * Format: email
+     *
      * @var string
      */
     public $email_address;
 
     /**
+     * The representative's phone number.
+     * [Optional]
+     *
      * @var Phone
      */
     public $phone;
 
     /**
+     * The representative's address.
+     * [Required]
+     *
      * @var Address
      */
     public $address;

--- a/lib/Checkout/Accounts/RepresentativeIndividual.php
+++ b/lib/Checkout/Accounts/RepresentativeIndividual.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Checkout\Accounts;
+
+use Checkout\Common\Address;
+use Checkout\Common\Phone;
+
+class RepresentativeIndividual
+{
+    /**
+     * @var string
+     */
+    public $first_name;
+
+    /**
+     * @var string
+     */
+    public $middle_name;
+
+    /**
+     * @var string
+     */
+    public $last_name;
+
+    /**
+     * @var DateOfBirth
+     */
+    public $date_of_birth;
+
+    /**
+     * @var PlaceOfBirth
+     */
+    public $place_of_birth;
+
+    /**
+     * @var string
+     */
+    public $national_id_number;
+
+    /**
+     * @var string
+     */
+    public $email_address;
+
+    /**
+     * @var Phone
+     */
+    public $phone;
+
+    /**
+     * @var Address
+     */
+    public $address;
+}

--- a/lib/Checkout/ApiClient.php
+++ b/lib/Checkout/ApiClient.php
@@ -31,12 +31,13 @@ class ApiClient
     /**
      * @param string $path
      * @param SdkAuthorization $authorization
+     * @param mixed $headers
      * @return array
      * @throws CheckoutApiException
      */
-    public function get(string $path, SdkAuthorization $authorization): array
+    public function get(string $path, SdkAuthorization $authorization, $headers = null): array
     {
-        return $this->invoke("GET", $path, null, $authorization);
+        return $this->invoke("GET", $path, null, $authorization, null, $headers);
     }
 
     /**
@@ -75,12 +76,13 @@ class ApiClient
      * @param string $path
      * @param mixed $requestBody
      * @param SdkAuthorization $authorization
+     * @param mixed $headers
      * @return array
      * @throws CheckoutApiException
      */
-    public function patch(string $path, $requestBody, SdkAuthorization $authorization): array
+    public function patch(string $path, $requestBody, SdkAuthorization $authorization, $headers = null): array
     {
-        return $this->invoke("PATCH", $path, $requestBody, $authorization);
+        return $this->invoke("PATCH", $path, $requestBody, $authorization, null, $headers);
     }
 
     /**
@@ -98,20 +100,22 @@ class ApiClient
      * @param string $path
      * @param AbstractQueryFilter $requestBody
      * @param SdkAuthorization $authorization
+     * @param mixed $headers
      * @return array
      * @throws CheckoutApiException
      */
     public function query(
         string $path,
         AbstractQueryFilter $requestBody,
-        SdkAuthorization $authorization
+        SdkAuthorization $authorization,
+        $headers = null
     ): array {
         $this->logger->info("GET " . $path);
         $queryParameters = $requestBody->getEncodedQueryParameters();
         if (!empty($queryParameters)) {
             $path .= "?" . $queryParameters;
         }
-        return $this->invoke("GET", $path, null, $authorization);
+        return $this->invoke("GET", $path, null, $authorization, null, $headers);
     }
 
     /**

--- a/test/Checkout/Tests/Accounts/AccountsIntegrationTest.php
+++ b/test/Checkout/Tests/Accounts/AccountsIntegrationTest.php
@@ -8,14 +8,12 @@ use Checkout\Accounts\Company;
 use Checkout\Accounts\ContactDetails;
 use Checkout\Accounts\DateOfBirth;
 use Checkout\Accounts\DateOfIncorporation;
-use Checkout\Accounts\Document;
 use Checkout\Accounts\EntityEmailAddresses;
 use Checkout\Accounts\EntityRoles;
-use Checkout\Accounts\Identification;
 use Checkout\Accounts\InstrumentDetailsFasterPayments;
 use Checkout\Accounts\InstrumentDocument;
 use Checkout\Accounts\OnboardEntityRequest;
-use Checkout\Accounts\OnboardSubEntityDocuments;
+use Checkout\Accounts\PlaceOfBirth;
 use Checkout\Accounts\ProcessingDetails;
 use Checkout\Accounts\ProcessingDetailsAch;
 use Checkout\Accounts\ProcessingDetailsPayments;
@@ -23,6 +21,7 @@ use Checkout\Accounts\PaymentInstrumentRequest;
 use Checkout\Accounts\PaymentInstrumentsQuery;
 use Checkout\Accounts\Profile;
 use Checkout\Accounts\Representative;
+use Checkout\Accounts\RepresentativeIndividual;
 use Checkout\Accounts\ReserveRules\Requests\CreateReserveRuleRequest;
 use Checkout\Accounts\ReserveRules\Requests\UpdateReserveRuleRequest;
 use Checkout\Accounts\ReserveRules\Entities\Rolling;
@@ -36,12 +35,18 @@ use Checkout\CheckoutSdk;
 use Checkout\Common\Country;
 use Checkout\Common\Currency;
 use Checkout\Common\InstrumentType;
+use Checkout\Common\Phone;
 use Checkout\OAuthScope;
 use Checkout\PlatformType;
 use Checkout\Tests\SandboxTestFixture;
 
 class AccountsIntegrationTest extends SandboxTestFixture
 {
+    /**
+     * @var CheckoutApi
+     */
+    private $accountsApi;
+
     /**
      * @before
      * @throws
@@ -59,11 +64,11 @@ class AccountsIntegrationTest extends SandboxTestFixture
     {
         $onboardEntityRequest = $this->buildOnboardCompanyRequest();
 
-        $response = $this->checkoutApi->getAccountsClient()->createEntity($onboardEntityRequest);
+        $response = $this->accountsApi()->getAccountsClient()->createEntity($onboardEntityRequest);
 
         $this->assertResponse($response, "id", "reference");
 
-        $response = $this->checkoutApi->getAccountsClient()->getEntity($response["id"]);
+        $response = $this->accountsApi()->getAccountsClient()->getEntity($response["id"]);
 
         $this->assertResponse(
             $response,
@@ -81,7 +86,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
 
         $onboardEntityRequest->company->trading_name = "Updated Trading Name";
 
-        $updateResponse = $this->checkoutApi->getAccountsClient()->updateEntity($response["id"], $onboardEntityRequest);
+        $updateResponse = $this->accountsApi()->getAccountsClient()->updateEntity($response["id"], $onboardEntityRequest);
 
         $this->assertResponse($updateResponse, "id");
 
@@ -96,7 +101,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
      */
     public function shouldCreateAndRetrievePaymentInstrument()
     {
-        $api = $this->getAccountsCheckoutApi();
+        $api = $this->accountsApi();
 
         $onboardEntityRequest = $this->buildOnboardCompanyRequest();
 
@@ -167,7 +172,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
     {
         $entityId = $this->createTestEntity();
 
-        $response = $this->checkoutApi->getAccountsClient()->getSubEntityMembers($entityId);
+        $response = $this->accountsApi()->getAccountsClient()->getSubEntityMembers($entityId);
 
         // Verify the response structure without requiring data to be non-empty
         $this->assertArrayHasKey("data", $response);
@@ -184,7 +189,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $entityId = $this->createTestEntity();
         
         // First get the actual sub-entity members
-        $membersResponse = $this->checkoutApi->getAccountsClient()->getSubEntityMembers($entityId);
+        $membersResponse = $this->accountsApi()->getAccountsClient()->getSubEntityMembers($entityId);
         $this->assertArrayHasKey("data", $membersResponse);
         $this->assertTrue(is_array($membersResponse["data"]));
         
@@ -200,7 +205,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $userId = $firstMember["user_id"];
 
         // Now reinvite the actual user
-        $response = $this->checkoutApi->getAccountsClient()->reinviteSubEntityMember($entityId, $userId);
+        $response = $this->accountsApi()->getAccountsClient()->reinviteSubEntityMember($entityId, $userId);
 
         $this->assertArrayHasKey("id", $response);
         $this->assertEquals($userId, $response["id"]);
@@ -216,7 +221,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $entityId = $this->createTestEntity();
         $request = $this->buildValidReserveRuleRequest();
 
-        $response = $this->checkoutApi->getAccountsClient()->createReserveRule($entityId, $request);
+        $response = $this->accountsApi()->getAccountsClient()->createReserveRule($entityId, $request);
 
         $this->validateReserveRuleIdResponse($response);
     }
@@ -232,9 +237,9 @@ class AccountsIntegrationTest extends SandboxTestFixture
         
         // First create a reserve rule
         $createRequest = $this->buildValidReserveRuleRequest();
-        $this->checkoutApi->getAccountsClient()->createReserveRule($entityId, $createRequest);
+        $this->accountsApi()->getAccountsClient()->createReserveRule($entityId, $createRequest);
 
-        $response = $this->checkoutApi->getAccountsClient()->getReserveRules($entityId);
+        $response = $this->accountsApi()->getAccountsClient()->getReserveRules($entityId);
 
         $this->validateReserveRulesResponse($response);
     }
@@ -250,10 +255,10 @@ class AccountsIntegrationTest extends SandboxTestFixture
         
         // First create a reserve rule
         $createRequest = $this->buildValidReserveRuleRequest();
-        $createResponse = $this->checkoutApi->getAccountsClient()->createReserveRule($entityId, $createRequest);
+        $createResponse = $this->accountsApi()->getAccountsClient()->createReserveRule($entityId, $createRequest);
         $reserveRuleId = $createResponse["id"];
 
-        $response = $this->checkoutApi->getAccountsClient()->getReserveRuleDetails($entityId, $reserveRuleId);
+        $response = $this->accountsApi()->getAccountsClient()->getReserveRuleDetails($entityId, $reserveRuleId);
 
         $this->validateReserveRuleResponse($response, $createRequest);
     }
@@ -269,7 +274,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
         
         // First create a reserve rule
         $createRequest = $this->buildValidReserveRuleRequest();
-        $createResponse = $this->checkoutApi->getAccountsClient()->createReserveRule($entityId, $createRequest);
+        $createResponse = $this->accountsApi()->getAccountsClient()->createReserveRule($entityId, $createRequest);
         
         $reserveRuleId = $createResponse["id"];
         
@@ -283,7 +288,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
         }
         
         $updateRequest = $this->buildUpdateReserveRuleRequest();
-        $response = $this->checkoutApi->getAccountsClient()->updateReserveRule($entityId, $reserveRuleId, $etag, $updateRequest);
+        $response = $this->accountsApi()->getAccountsClient()->updateReserveRule($entityId, $reserveRuleId, $etag, $updateRequest);
 
         $this->validateReserveRuleIdResponse($response);
     }
@@ -299,13 +304,13 @@ class AccountsIntegrationTest extends SandboxTestFixture
 
         // Test upload file
         $uploadRequest = $this->buildFileUploadRequest();
-        $uploadResponse = $this->checkoutApi->getAccountsClient()->uploadFile($entityId, $uploadRequest);
+        $uploadResponse = $this->accountsApi()->getAccountsClient()->uploadFile($entityId, $uploadRequest);
 
         $this->validateFileUploadResponse($uploadResponse);
 
         // Test retrieve file id
         $fileId = $uploadResponse["id"];
-        $retrieveResponse = $this->checkoutApi->getAccountsClient()->retrieveFile($entityId, $fileId);
+        $retrieveResponse = $this->accountsApi()->getAccountsClient()->retrieveFile($entityId, $fileId);
         $this->validateFileRetrieveResponse($retrieveResponse);
     }
 
@@ -318,7 +323,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
     private function createTestEntity()
     {
         $onboardEntityRequest = $this->buildOnboardCompanyRequest();
-        $response = $this->checkoutApi->getAccountsClient()->createEntity($onboardEntityRequest);
+        $response = $this->accountsApi()->getAccountsClient()->createEntity($onboardEntityRequest);
         return $response["id"];
     }
 
@@ -336,26 +341,23 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $onboardEntityRequest = new OnboardEntityRequest();
         $onboardEntityRequest->reference = uniqid("test_entity_");
 
+        $phone = new Phone();
+        $phone->country_code = "GB";
+        $phone->number = "2072343000";
+
         $emailAddresses = new EntityEmailAddresses();
         $emailAddresses->primary = $this->randomEmail();
         $onboardEntityRequest->contact_details = new ContactDetails();
-        $onboardEntityRequest->contact_details->phone = $this->getPhone();
+        $onboardEntityRequest->contact_details->phone = $phone;
         $onboardEntityRequest->contact_details->email_addresses = $emailAddresses;
 
+        // The holding currency scope is configured on the platform (USD here), while the
+        // processing_details currency reflects the sub-entity region (GBP); they are independent.
         $onboardEntityRequest->profile = new Profile();
         $onboardEntityRequest->profile->urls = array("https://www.example-test-entity.com");
         $onboardEntityRequest->profile->mccs = array("0742");
-        $onboardEntityRequest->profile->default_holding_currency = Currency::$GBP;
-        $onboardEntityRequest->profile->holding_currencies = array(Currency::$GBP);
-
-        $representative = new Representative();
-        $representative->first_name = "John";
-        $representative->last_name = "Representative";
-        $representative->address = $this->getAddress();
-        $representative->identification = new Identification();
-        $representative->identification->national_id_number = "AB123456C";
-        $representative->date_of_birth = $this->getDateOfBirth();
-        $representative->phone = $this->getPhone();
+        $onboardEntityRequest->profile->default_holding_currency = Currency::$USD;
+        $onboardEntityRequest->profile->holding_currencies = array(Currency::$USD);
 
         $dateOfIncorporation = new DateOfIncorporation();
         $dateOfIncorporation->day = 1;
@@ -370,12 +372,40 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $onboardEntityRequest->company->date_of_incorporation = $dateOfIncorporation;
         $onboardEntityRequest->company->principal_address = $this->getAddress();
         $onboardEntityRequest->company->registered_address = $this->getAddress();
-        $onboardEntityRequest->company->representatives = array($representative);
+        $onboardEntityRequest->company->representatives = array($this->buildRepresentative());
 
         $onboardEntityRequest->processing_details = $this->buildProcessingDetails();
-        $onboardEntityRequest->documents = $this->buildOnboardDocuments();
 
         return $onboardEntityRequest;
+    }
+
+    /**
+     * Builds a v3.0 "person of interest" representative (nested individual details + roles).
+     *
+     * @return Representative
+     */
+    private function buildRepresentative()
+    {
+        $placeOfBirth = new PlaceOfBirth();
+        $placeOfBirth->country = Country::$GB;
+
+        $individual = new RepresentativeIndividual();
+        $individual->first_name = "John";
+        $individual->last_name = "Representative";
+        $individual->date_of_birth = $this->getDateOfBirth();
+        $individual->place_of_birth = $placeOfBirth;
+        $individual->address = $this->getAddress();
+
+        $representative = new Representative();
+        $representative->individual = $individual;
+        $representative->roles = array(
+            EntityRoles::$ubo,
+            EntityRoles::$authorised_signatory,
+            EntityRoles::$director,
+            EntityRoles::$control_person
+        );
+
+        return $representative;
     }
 
     /**
@@ -403,32 +433,6 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $processingDetails->payments = $payments;
 
         return $processingDetails;
-    }
-
-    /**
-     * Builds the documents object required by the Accounts API v3.0 full onboarding variant.
-     * Each document references a real file uploaded through the Accounts Files API.
-     *
-     * @return OnboardSubEntityDocuments
-     * @throws CheckoutApiException
-     */
-    private function buildOnboardDocuments()
-    {
-        $fileId = $this->uploadFile()["id"];
-
-        $articlesOfAssociation = new Document();
-        $articlesOfAssociation->type = "articles_of_association";
-        $articlesOfAssociation->front = $fileId;
-
-        $shareholderStructure = new Document();
-        $shareholderStructure->type = "shareholder_structure";
-        $shareholderStructure->front = $fileId;
-
-        $documents = new OnboardSubEntityDocuments();
-        $documents->articles_of_association = $articlesOfAssociation;
-        $documents->shareholder_structure = $shareholderStructure;
-
-        return $documents;
     }
 
     /**
@@ -568,6 +572,22 @@ class AccountsIntegrationTest extends SandboxTestFixture
     }
 
     /**
+     * The Accounts API v3.0 onboarding is only available on the accounts-scoped OAuth client,
+     * so every sub-entity operation in this suite goes through it (memoized).
+     *
+     * @return CheckoutApi
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
+    private function accountsApi()
+    {
+        if ($this->accountsApi === null) {
+            $this->accountsApi = $this->getAccountsCheckoutApi();
+        }
+        return $this->accountsApi;
+    }
+
+    /**
      * @return CheckoutApi
      * @throws CheckoutArgumentException
      * @throws CheckoutException
@@ -579,7 +599,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
                 getenv("CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID"),
                 getenv("CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET")
             )
-            ->scopes([OAuthScope::$Accounts])
+            ->scopes([OAuthScope::$Accounts, OAuthScope::$Files])
             ->build();
     }
 
@@ -594,7 +614,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $fileRequest->content_type = "image/jpeg";
         $fileRequest->purpose = "bank_verification";
 
-        $response = $this->checkoutApi->getAccountsClient()->submitFile($fileRequest);
+        $response = $this->accountsApi()->getAccountsClient()->submitFile($fileRequest);
 
         $this->assertResponse($response, "id");
 

--- a/test/Checkout/Tests/Accounts/AccountsIntegrationTest.php
+++ b/test/Checkout/Tests/Accounts/AccountsIntegrationTest.php
@@ -3,16 +3,22 @@
 namespace Checkout\Tests\Accounts;
 
 use Checkout\Accounts\AccountsFileRequest;
+use Checkout\Accounts\BusinessType;
 use Checkout\Accounts\Company;
 use Checkout\Accounts\ContactDetails;
 use Checkout\Accounts\DateOfBirth;
+use Checkout\Accounts\DateOfIncorporation;
+use Checkout\Accounts\Document;
 use Checkout\Accounts\EntityEmailAddresses;
 use Checkout\Accounts\EntityRoles;
 use Checkout\Accounts\Identification;
-use Checkout\Accounts\Individual;
 use Checkout\Accounts\InstrumentDetailsFasterPayments;
 use Checkout\Accounts\InstrumentDocument;
 use Checkout\Accounts\OnboardEntityRequest;
+use Checkout\Accounts\OnboardSubEntityDocuments;
+use Checkout\Accounts\ProcessingDetails;
+use Checkout\Accounts\ProcessingDetailsAch;
+use Checkout\Accounts\ProcessingDetailsPayments;
 use Checkout\Accounts\PaymentInstrumentRequest;
 use Checkout\Accounts\PaymentInstrumentsQuery;
 use Checkout\Accounts\Profile;
@@ -51,24 +57,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
      */
     public function shouldCreateGetAndUpdateOnboardEntity()
     {
-        $onboardEntityRequest = new OnboardEntityRequest();
-        $onboardEntityRequest->reference = uniqid();
-        $emailAddresses = new EntityEmailAddresses();
-        $emailAddresses->primary = $this->randomEmail();
-        $onboardEntityRequest->contact_details = new ContactDetails();
-        $onboardEntityRequest->contact_details->phone = $this->getPhone();
-        $onboardEntityRequest->contact_details->email_addresses = $emailAddresses;
-        $onboardEntityRequest->profile = new Profile();
-        $onboardEntityRequest->profile->urls = array("https://www.superheroexample.com");
-        $onboardEntityRequest->profile->mccs = array("0742");
-        $onboardEntityRequest->individual = new Individual();
-        $onboardEntityRequest->individual->first_name = "Bruce";
-        $onboardEntityRequest->individual->last_name = "Wayne";
-        $onboardEntityRequest->individual->trading_name = "Batman's Super Hero Masks";
-        $onboardEntityRequest->individual->registered_address = $this->getAddress();
-        $onboardEntityRequest->individual->national_tax_id = "TAX123456";
-        $onboardEntityRequest->individual->date_of_birth = $this->getDateOfBirth();
-        $onboardEntityRequest->individual->identification = $this->getTestIdentification();
+        $onboardEntityRequest = $this->buildOnboardCompanyRequest();
 
         $response = $this->checkoutApi->getAccountsClient()->createEntity($onboardEntityRequest);
 
@@ -84,14 +73,13 @@ class AccountsIntegrationTest extends SandboxTestFixture
             "contact_details.phone",
             "contact_details.phone.number",
             "contact_details.email_addresses.primary",
-            "individual",
-            "individual.first_name",
-            "individual.last_name",
-            "individual.trading_name",
-            "individual.national_tax_id"
+            "company",
+            "company.legal_name",
+            "company.trading_name",
+            "company.business_registration_number"
         );
 
-        $onboardEntityRequest->individual->first_name = "John";
+        $onboardEntityRequest->company->trading_name = "Updated Trading Name";
 
         $updateResponse = $this->checkoutApi->getAccountsClient()->updateEntity($response["id"], $onboardEntityRequest);
 
@@ -110,29 +98,7 @@ class AccountsIntegrationTest extends SandboxTestFixture
     {
         $api = $this->getAccountsCheckoutApi();
 
-        $representative = new Representative();
-        $representative->first_name = "John";
-        $representative->last_name = "Montana";
-        $representative->address = $this->getAddress();
-        $representative->identification = new Identification();
-        $representative->identification->national_id_number = "AB123456C";
-
-        $onboardEntityRequest = new OnboardEntityRequest();
-        $onboardEntityRequest->reference = uniqid();
-        $onboardEntityRequest->contact_details = new ContactDetails();
-        $onboardEntityRequest->contact_details->phone = $this->getPhone();
-        $onboardEntityRequest->contact_details->email_addresses = new EntityEmailAddresses();
-        $onboardEntityRequest->contact_details->email_addresses->primary = $this->randomEmail();
-        $onboardEntityRequest->profile = new Profile();
-        $onboardEntityRequest->profile->urls = array("https://www.superheroexample.com");
-        $onboardEntityRequest->profile->mccs = array("0742");
-        $onboardEntityRequest->company = new Company();
-        $onboardEntityRequest->company->business_registration_number = "01234567";
-        $onboardEntityRequest->company->legal_name = "Super Hero Masks Inc.";
-        $onboardEntityRequest->company->trading_name = "Super Hero Masks";
-        $onboardEntityRequest->company->principal_address = $this->getAddress();
-        $onboardEntityRequest->company->registered_address = $this->getAddress();
-        $onboardEntityRequest->company->representatives = array($representative);
+        $onboardEntityRequest = $this->buildOnboardCompanyRequest();
 
         $entity = $api->getAccountsClient()->createEntity($onboardEntityRequest);
 
@@ -190,14 +156,6 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $dateOfBirth->year = 1996;
 
         return $dateOfBirth;
-    }
-
-    private function getTestIdentification()
-    {
-        $identification = new Identification();
-        $identification->national_id_number = "AB123456C";
-
-        return $identification;
     }
 
     /**
@@ -359,22 +317,37 @@ class AccountsIntegrationTest extends SandboxTestFixture
      */
     private function createTestEntity()
     {
+        $onboardEntityRequest = $this->buildOnboardCompanyRequest();
+        $response = $this->checkoutApi->getAccountsClient()->createEntity($onboardEntityRequest);
+        return $response["id"];
+    }
+
+    /**
+     * Builds a company OnboardEntityRequest that conforms to the Accounts API v3.0 schema.
+     * v3.0 dropped the top-level "individual" field and added the required
+     * "processing_details" object (and "date_of_incorporation"/"business_type" on the company);
+     * "documents" is required for the full onboarding variant.
+     *
+     * @return OnboardEntityRequest
+     * @throws CheckoutApiException
+     */
+    private function buildOnboardCompanyRequest()
+    {
         $onboardEntityRequest = new OnboardEntityRequest();
         $onboardEntityRequest->reference = uniqid("test_entity_");
-        
-        // Add required contact details
+
         $emailAddresses = new EntityEmailAddresses();
         $emailAddresses->primary = $this->randomEmail();
         $onboardEntityRequest->contact_details = new ContactDetails();
         $onboardEntityRequest->contact_details->phone = $this->getPhone();
         $onboardEntityRequest->contact_details->email_addresses = $emailAddresses;
 
-        // Add required profile information
         $onboardEntityRequest->profile = new Profile();
         $onboardEntityRequest->profile->urls = array("https://www.example-test-entity.com");
         $onboardEntityRequest->profile->mccs = array("0742");
-        
-        // Create a Company entity with Representatives (generates sub-entity members)
+        $onboardEntityRequest->profile->default_holding_currency = Currency::$GBP;
+        $onboardEntityRequest->profile->holding_currencies = array(Currency::$GBP);
+
         $representative = new Representative();
         $representative->first_name = "John";
         $representative->last_name = "Representative";
@@ -383,18 +356,79 @@ class AccountsIntegrationTest extends SandboxTestFixture
         $representative->identification->national_id_number = "AB123456C";
         $representative->date_of_birth = $this->getDateOfBirth();
         $representative->phone = $this->getPhone();
-        
-        // Set up the company details
+
+        $dateOfIncorporation = new DateOfIncorporation();
+        $dateOfIncorporation->day = 1;
+        $dateOfIncorporation->month = 6;
+        $dateOfIncorporation->year = 2010;
+
         $onboardEntityRequest->company = new Company();
         $onboardEntityRequest->company->business_registration_number = "01234567";
+        $onboardEntityRequest->company->business_type = BusinessType::$limited_company;
         $onboardEntityRequest->company->legal_name = "Test Sub-Entity Company Inc.";
         $onboardEntityRequest->company->trading_name = "Test Sub-Entity Trading";
+        $onboardEntityRequest->company->date_of_incorporation = $dateOfIncorporation;
         $onboardEntityRequest->company->principal_address = $this->getAddress();
         $onboardEntityRequest->company->registered_address = $this->getAddress();
         $onboardEntityRequest->company->representatives = array($representative);
 
-        $response = $this->checkoutApi->getAccountsClient()->createEntity($onboardEntityRequest);
-        return $response["id"];
+        $onboardEntityRequest->processing_details = $this->buildProcessingDetails();
+        $onboardEntityRequest->documents = $this->buildOnboardDocuments();
+
+        return $onboardEntityRequest;
+    }
+
+    /**
+     * Builds the processing_details object required by the Accounts API v3.0 schema.
+     *
+     * @return ProcessingDetails
+     */
+    private function buildProcessingDetails()
+    {
+        $ach = new ProcessingDetailsAch();
+        $ach->annual_ach_volume = 1000000;
+        $ach->average_ach_transaction_size = 5000;
+        $ach->estimated_monthly_credit_volume = 100000;
+        $ach->average_credit_amount = 5000;
+
+        $payments = new ProcessingDetailsPayments();
+        $payments->ach = $ach;
+
+        $processingDetails = new ProcessingDetails();
+        $processingDetails->annual_processing_volume = 1000000;
+        $processingDetails->average_transaction_value = 5000;
+        $processingDetails->average_order_fulfillment_time = 3;
+        $processingDetails->currency = Currency::$GBP;
+        $processingDetails->target_countries = array(Country::$GB);
+        $processingDetails->payments = $payments;
+
+        return $processingDetails;
+    }
+
+    /**
+     * Builds the documents object required by the Accounts API v3.0 full onboarding variant.
+     * Each document references a real file uploaded through the Accounts Files API.
+     *
+     * @return OnboardSubEntityDocuments
+     * @throws CheckoutApiException
+     */
+    private function buildOnboardDocuments()
+    {
+        $fileId = $this->uploadFile()["id"];
+
+        $articlesOfAssociation = new Document();
+        $articlesOfAssociation->type = "articles_of_association";
+        $articlesOfAssociation->front = $fileId;
+
+        $shareholderStructure = new Document();
+        $shareholderStructure->type = "shareholder_structure";
+        $shareholderStructure->front = $fileId;
+
+        $documents = new OnboardSubEntityDocuments();
+        $documents->articles_of_association = $articlesOfAssociation;
+        $documents->shareholder_structure = $shareholderStructure;
+
+        return $documents;
     }
 
     /**

--- a/test/Checkout/Tests/Accounts/AccountsSchemaVersionHeaderTest.php
+++ b/test/Checkout/Tests/Accounts/AccountsSchemaVersionHeaderTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\AccountsClient;
+use Checkout\Accounts\OnboardEntityRequest;
+use Checkout\ApiClient;
+use Checkout\CheckoutConfiguration;
+use Checkout\Environment;
+use Checkout\HttpClientBuilderInterface;
+use Checkout\PlatformType;
+use Checkout\SdkAuthorization;
+use Checkout\SdkCredentialsInterface;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Http\Message\RequestInterface;
+
+class AccountsSchemaVersionHeaderTest extends MockeryTestCase
+{
+    /**
+     * @var RequestInterface|null
+     */
+    private $capturedRequest;
+
+    /**
+     * Builds a Guzzle client that captures the outgoing request and returns a fake 200 JSON response.
+     */
+    private function createCapturingHttpClient(): \GuzzleHttp\Client
+    {
+        $this->capturedRequest = null;
+
+        $stack = HandlerStack::create();
+        $stack->after('prepare_body', function (callable $handler) {
+            return function ($request, array $options) use ($handler) {
+                $this->capturedRequest = $request;
+                return $handler($request, $options);
+            };
+        }, 'capture_request');
+
+        $stack->setHandler(function () {
+            return \GuzzleHttp\Promise\Create::promiseFor(
+                new Response(200, ['Content-Type' => 'application/json'], '{"id":"ent_123"}')
+            );
+        });
+
+        return new \GuzzleHttp\Client([
+            'handler' => $stack,
+            'base_uri' => 'https://api.sandbox.checkout.com/',
+        ]);
+    }
+
+    private function buildAccountsClient(): AccountsClient
+    {
+        $sdkAuthorization = new SdkAuthorization(PlatformType::$default, 'sk_test_xxx');
+        $sdkCredentials = $this->createMock(SdkCredentialsInterface::class);
+        $sdkCredentials->method('getAuthorization')->willReturn($sdkAuthorization);
+
+        $httpBuilder = $this->createMock(HttpClientBuilderInterface::class);
+        $httpBuilder->method('getClient')->willReturn($this->createCapturingHttpClient());
+
+        $logger = new Logger('checkout-sdk-test-php');
+        $logger->pushHandler(new StreamHandler('php://stderr'));
+        $logger->pushHandler(new StreamHandler('checkout-sdk-test-php.log'));
+
+        $configuration = new CheckoutConfiguration(
+            $sdkCredentials,
+            Environment::sandbox(),
+            $httpBuilder,
+            $logger
+        );
+
+        $apiClient = new ApiClient($configuration);
+        return new AccountsClient($apiClient, $apiClient, $configuration);
+    }
+
+    private function assertAcceptHeader(string $expected)
+    {
+        $this->assertNotNull($this->capturedRequest, 'Expected the outgoing request to have been captured');
+        $this->assertEquals(
+            $expected,
+            $this->capturedRequest->getHeaderLine('Accept'),
+            'Accounts entity operations must negotiate the schema version through the Accept header'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function createEntitySendsSchemaVersion3ByDefault()
+    {
+        $this->buildAccountsClient()->createEntity(new OnboardEntityRequest());
+        $this->assertAcceptHeader('application/json;schema_version=3.0');
+    }
+
+    /**
+     * @test
+     */
+    public function getEntitySendsSchemaVersion3ByDefault()
+    {
+        $this->buildAccountsClient()->getEntity('ent_123');
+        $this->assertAcceptHeader('application/json;schema_version=3.0');
+    }
+
+    /**
+     * @test
+     */
+    public function updateEntitySendsSchemaVersion3ByDefault()
+    {
+        $this->buildAccountsClient()->updateEntity('ent_123', new OnboardEntityRequest());
+        $this->assertAcceptHeader('application/json;schema_version=3.0');
+    }
+
+    /**
+     * @test
+     */
+    public function getEntityRequirementsSendsSchemaVersion3ByDefault()
+    {
+        $this->buildAccountsClient()->getEntityRequirements('ent_123');
+        $this->assertAcceptHeader('application/json;schema_version=3.0');
+    }
+
+    /**
+     * @test
+     */
+    public function allowsOverridingTheSchemaVersion()
+    {
+        $this->buildAccountsClient()->getEntity('ent_123', '2.0');
+        $this->assertAcceptHeader('application/json;schema_version=2.0');
+    }
+}

--- a/test/Checkout/Tests/Accounts/AgreedTermsSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/AgreedTermsSerializationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\AgreedTerms;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class AgreedTermsSerializationTest extends TestCase
+{
+    public function testAgreedTermsRoundTrip()
+    {
+        $agreedTerms = new AgreedTerms();
+        $agreedTerms->date = "2026-07-20T10:00:00Z";
+        $agreedTerms->ip_address = "203.0.113.42";
+        $agreedTerms->name = "John Representative";
+        $agreedTerms->email = "john@example.com";
+        $agreedTerms->version = "1.0";
+
+        $decoded = json_decode((new JsonSerializer())->serialize($agreedTerms), true);
+
+        $this->assertSame("2026-07-20T10:00:00Z", $decoded['date']);
+        $this->assertSame("203.0.113.42", $decoded['ip_address']);
+        $this->assertSame("John Representative", $decoded['name']);
+        $this->assertSame("john@example.com", $decoded['email']);
+        $this->assertSame("1.0", $decoded['version']);
+    }
+}

--- a/test/Checkout/Tests/Accounts/CompanySerializationTest.php
+++ b/test/Checkout/Tests/Accounts/CompanySerializationTest.php
@@ -4,6 +4,7 @@ namespace Checkout\Tests\Accounts;
 
 use Checkout\Accounts\BusinessType;
 use Checkout\Accounts\Company;
+use Checkout\Accounts\CompanyPosition;
 use Checkout\Accounts\DateOfBirth;
 use Checkout\Accounts\DateOfIncorporation;
 use Checkout\Accounts\EntityRoles;
@@ -31,6 +32,7 @@ class CompanySerializationTest extends TestCase
         $company->trading_name = "Super Hero Masks";
         $company->additional_trading_names = array("SHM");
         $company->is_registered_company = true;
+        $company->regulatory_licence_number = "REG-123456";
         $company->date_of_incorporation = $dateOfIncorporation;
         $company->representatives = array($this->buildRepresentative());
 
@@ -42,11 +44,14 @@ class CompanySerializationTest extends TestCase
         $this->assertSame("Super Hero Masks", $decoded['trading_name']);
         $this->assertSame(array("SHM"), $decoded['additional_trading_names']);
         $this->assertTrue($decoded['is_registered_company']);
+        $this->assertSame("REG-123456", $decoded['regulatory_licence_number']);
         $this->assertSame(2010, $decoded['date_of_incorporation']['year']);
 
         $representative = $decoded['representatives'][0];
         $this->assertSame("John", $representative['individual']['first_name']);
         $this->assertSame("GB", $representative['individual']['place_of_birth']['country']);
+        $this->assertSame("ceo", $representative['company_position']);
+        $this->assertSame(100, $representative['ownership_percentage']);
         $this->assertSame(
             array("ubo", "authorised_signatory", "director", "control_person"),
             $representative['roles']
@@ -60,6 +65,24 @@ class CompanySerializationTest extends TestCase
         $this->assertSame("director", EntityRoles::$director);
         $this->assertSame("control_person", EntityRoles::$control_person);
         $this->assertSame("legal_representative", EntityRoles::$legal_representative);
+    }
+
+    public function testBusinessTypeValuesMatchSwagger()
+    {
+        $this->assertSame("individual_or_sole_proprietorship", BusinessType::$individual_or_sole_proprietorship);
+        $this->assertSame("limited_liability_corporation", BusinessType::$limited_liability_corporation);
+        $this->assertSame("government_agency", BusinessType::$government_agency);
+        $this->assertSame("non_profit_entity", BusinessType::$non_profit_entity);
+        $this->assertSame("trust", BusinessType::$trust);
+        $this->assertSame("scottish_limited_partnership", BusinessType::$scottish_limited_partnership);
+    }
+
+    public function testCompanyPositionValuesMatchSwagger()
+    {
+        $this->assertSame("ceo", CompanyPosition::$ceo);
+        $this->assertSame("managing_member", CompanyPosition::$managing_member);
+        $this->assertSame("general_partner", CompanyPosition::$general_partner);
+        $this->assertSame("other_non_executive_non_senior", CompanyPosition::$other_non_executive_non_senior);
     }
 
     private function buildRepresentative()
@@ -87,6 +110,8 @@ class CompanySerializationTest extends TestCase
 
         $representative = new Representative();
         $representative->individual = $individual;
+        $representative->company_position = CompanyPosition::$ceo;
+        $representative->ownership_percentage = 100;
         $representative->roles = array(
             EntityRoles::$ubo,
             EntityRoles::$authorised_signatory,

--- a/test/Checkout/Tests/Accounts/CompanySerializationTest.php
+++ b/test/Checkout/Tests/Accounts/CompanySerializationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\BusinessType;
+use Checkout\Accounts\Company;
+use Checkout\Accounts\DateOfBirth;
+use Checkout\Accounts\DateOfIncorporation;
+use Checkout\Accounts\EntityRoles;
+use Checkout\Accounts\PlaceOfBirth;
+use Checkout\Accounts\Representative;
+use Checkout\Accounts\RepresentativeIndividual;
+use Checkout\Common\Address;
+use Checkout\Common\Country;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class CompanySerializationTest extends TestCase
+{
+    public function testCompanyWithV3RepresentativeRoundTrip()
+    {
+        $dateOfIncorporation = new DateOfIncorporation();
+        $dateOfIncorporation->day = 1;
+        $dateOfIncorporation->month = 6;
+        $dateOfIncorporation->year = 2010;
+
+        $company = new Company();
+        $company->business_registration_number = "01234567";
+        $company->business_type = BusinessType::$limited_company;
+        $company->legal_name = "Super Hero Masks Inc.";
+        $company->trading_name = "Super Hero Masks";
+        $company->additional_trading_names = array("SHM");
+        $company->is_registered_company = true;
+        $company->date_of_incorporation = $dateOfIncorporation;
+        $company->representatives = array($this->buildRepresentative());
+
+        $decoded = json_decode((new JsonSerializer())->serialize($company), true);
+
+        $this->assertSame("01234567", $decoded['business_registration_number']);
+        $this->assertSame("limited_company", $decoded['business_type']);
+        $this->assertSame("Super Hero Masks Inc.", $decoded['legal_name']);
+        $this->assertSame("Super Hero Masks", $decoded['trading_name']);
+        $this->assertSame(array("SHM"), $decoded['additional_trading_names']);
+        $this->assertTrue($decoded['is_registered_company']);
+        $this->assertSame(2010, $decoded['date_of_incorporation']['year']);
+
+        $representative = $decoded['representatives'][0];
+        $this->assertSame("John", $representative['individual']['first_name']);
+        $this->assertSame("GB", $representative['individual']['place_of_birth']['country']);
+        $this->assertSame(
+            array("ubo", "authorised_signatory", "director", "control_person"),
+            $representative['roles']
+        );
+    }
+
+    public function testRolesSerializeToExactSwaggerValues()
+    {
+        $this->assertSame("ubo", EntityRoles::$ubo);
+        $this->assertSame("authorised_signatory", EntityRoles::$authorised_signatory);
+        $this->assertSame("director", EntityRoles::$director);
+        $this->assertSame("control_person", EntityRoles::$control_person);
+        $this->assertSame("legal_representative", EntityRoles::$legal_representative);
+    }
+
+    private function buildRepresentative()
+    {
+        $dateOfBirth = new DateOfBirth();
+        $dateOfBirth->day = 5;
+        $dateOfBirth->month = 6;
+        $dateOfBirth->year = 1996;
+
+        $placeOfBirth = new PlaceOfBirth();
+        $placeOfBirth->country = Country::$GB;
+
+        $address = new Address();
+        $address->address_line1 = "CheckoutSdk.com";
+        $address->city = "London";
+        $address->zip = "W1T 4TJ";
+        $address->country = Country::$GB;
+
+        $individual = new RepresentativeIndividual();
+        $individual->first_name = "John";
+        $individual->last_name = "Representative";
+        $individual->date_of_birth = $dateOfBirth;
+        $individual->place_of_birth = $placeOfBirth;
+        $individual->address = $address;
+
+        $representative = new Representative();
+        $representative->individual = $individual;
+        $representative->roles = array(
+            EntityRoles::$ubo,
+            EntityRoles::$authorised_signatory,
+            EntityRoles::$director,
+            EntityRoles::$control_person
+        );
+
+        return $representative;
+    }
+}

--- a/test/Checkout/Tests/Accounts/DateOfIncorporationSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/DateOfIncorporationSerializationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\DateOfIncorporation;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class DateOfIncorporationSerializationTest extends TestCase
+{
+    public function testDateOfIncorporationRoundTrip()
+    {
+        $dateOfIncorporation = new DateOfIncorporation();
+        $dateOfIncorporation->day = 1;
+        $dateOfIncorporation->month = 6;
+        $dateOfIncorporation->year = 2010;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($dateOfIncorporation), true);
+
+        $this->assertSame(1, $decoded['day']);
+        $this->assertSame(6, $decoded['month']);
+        $this->assertSame(2010, $decoded['year']);
+    }
+
+    public function testDateOfIncorporationOmitsNullDay()
+    {
+        $dateOfIncorporation = new DateOfIncorporation();
+        $dateOfIncorporation->month = 6;
+        $dateOfIncorporation->year = 2010;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($dateOfIncorporation), true);
+
+        $this->assertArrayNotHasKey('day', $decoded);
+        $this->assertSame(6, $decoded['month']);
+        $this->assertSame(2010, $decoded['year']);
+    }
+}

--- a/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\AgreedTerms;
+use Checkout\Accounts\Document;
+use Checkout\Accounts\OnboardEntityRequest;
+use Checkout\Accounts\OnboardSubEntityDocuments;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class OnboardEntityRequestSerializationTest extends TestCase
+{
+    public function testOnboardEntityRequestRoundTrip()
+    {
+        $agreedTerms = new AgreedTerms();
+        $agreedTerms->date = "2026-07-20T10:00:00Z";
+        $agreedTerms->ip_address = "203.0.113.42";
+        $agreedTerms->name = "John Representative";
+        $agreedTerms->email = "john@example.com";
+        $agreedTerms->version = "1.0";
+
+        $request = new OnboardEntityRequest();
+        $request->reference = "ref_123";
+        $request->seller_category = "cat_electronics";
+        $request->agreed_terms = $agreedTerms;
+        $request->documents = $this->buildDocuments();
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame("ref_123", $decoded['reference']);
+        $this->assertSame("cat_electronics", $decoded['seller_category']);
+        $this->assertSame("john@example.com", $decoded['agreed_terms']['email']);
+        $this->assertSame("2026-07-20T10:00:00Z", $decoded['agreed_terms']['date']);
+    }
+
+    public function testDocumentsRoundTripIncludingFinancialStatements()
+    {
+        $decoded = json_decode((new JsonSerializer())->serialize($this->buildDocuments()), true);
+
+        $this->assertSame("articles_of_association", $decoded['articles_of_association']['type']);
+        $this->assertSame("file_1", $decoded['articles_of_association']['front']);
+        $this->assertSame("certified_shareholder_structure", $decoded['shareholder_structure']['type']);
+        $this->assertSame("financial_statements", $decoded['financial_statements']['type']);
+        $this->assertSame("file_2", $decoded['financial_statements']['front']);
+    }
+
+    private function buildDocuments()
+    {
+        $articles = new Document();
+        $articles->type = "articles_of_association";
+        $articles->front = "file_1";
+
+        $shareholder = new Document();
+        $shareholder->type = "certified_shareholder_structure";
+        $shareholder->front = "file_1";
+
+        $financialStatements = new Document();
+        $financialStatements->type = "financial_statements";
+        $financialStatements->front = "file_2";
+
+        $documents = new OnboardSubEntityDocuments();
+        $documents->articles_of_association = $articles;
+        $documents->shareholder_structure = $shareholder;
+        $documents->financial_statements = $financialStatements;
+
+        return $documents;
+    }
+}

--- a/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
@@ -23,6 +23,7 @@ class OnboardEntityRequestSerializationTest extends TestCase
         $request = new OnboardEntityRequest();
         $request->reference = "ref_123";
         $request->seller_category = "cat_electronics";
+        $request->is_draft = true;
         $request->agreed_terms = $agreedTerms;
         $request->documents = $this->buildDocuments();
 
@@ -30,6 +31,7 @@ class OnboardEntityRequestSerializationTest extends TestCase
 
         $this->assertSame("ref_123", $decoded['reference']);
         $this->assertSame("cat_electronics", $decoded['seller_category']);
+        $this->assertTrue($decoded['is_draft']);
         $this->assertSame("john@example.com", $decoded['agreed_terms']['email']);
         $this->assertSame("2026-07-20T10:00:00Z", $decoded['agreed_terms']['date']);
     }
@@ -43,6 +45,8 @@ class OnboardEntityRequestSerializationTest extends TestCase
         $this->assertSame("certified_shareholder_structure", $decoded['shareholder_structure']['type']);
         $this->assertSame("financial_statements", $decoded['financial_statements']['type']);
         $this->assertSame("file_2", $decoded['financial_statements']['front']);
+        $this->assertSame("financial_verification", $decoded['financial_verification']['type']);
+        $this->assertSame("file_3", $decoded['financial_verification']['front']);
     }
 
     private function buildDocuments()
@@ -59,10 +63,15 @@ class OnboardEntityRequestSerializationTest extends TestCase
         $financialStatements->type = "financial_statements";
         $financialStatements->front = "file_2";
 
+        $financialVerification = new Document();
+        $financialVerification->type = "financial_verification";
+        $financialVerification->front = "file_3";
+
         $documents = new OnboardSubEntityDocuments();
         $documents->articles_of_association = $articles;
         $documents->shareholder_structure = $shareholder;
         $documents->financial_statements = $financialStatements;
+        $documents->financial_verification = $financialVerification;
 
         return $documents;
     }

--- a/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
@@ -3,9 +3,11 @@
 namespace Checkout\Tests\Accounts;
 
 use Checkout\Accounts\AgreedTerms;
+use Checkout\Accounts\CompanyVerification;
 use Checkout\Accounts\Document;
 use Checkout\Accounts\OnboardEntityRequest;
 use Checkout\Accounts\OnboardSubEntityDocuments;
+use Checkout\Accounts\TaxVerification;
 use Checkout\JsonSerializer;
 use PHPUnit\Framework\TestCase;
 
@@ -36,43 +38,76 @@ class OnboardEntityRequestSerializationTest extends TestCase
         $this->assertSame("2026-07-20T10:00:00Z", $decoded['agreed_terms']['date']);
     }
 
-    public function testDocumentsRoundTripIncludingFinancialStatements()
+    public function testDocumentsRoundTripCoversEveryField()
     {
         $decoded = json_decode((new JsonSerializer())->serialize($this->buildDocuments()), true);
 
-        $this->assertSame("articles_of_association", $decoded['articles_of_association']['type']);
-        $this->assertSame("file_1", $decoded['articles_of_association']['front']);
-        $this->assertSame("certified_shareholder_structure", $decoded['shareholder_structure']['type']);
-        $this->assertSame("financial_statements", $decoded['financial_statements']['type']);
-        $this->assertSame("file_2", $decoded['financial_statements']['front']);
-        $this->assertSame("financial_verification", $decoded['financial_verification']['type']);
-        $this->assertSame("file_3", $decoded['financial_verification']['front']);
+        // Every property of OnboardSubEntityDocuments must serialize with its type + front.
+        $expectedTypes = array(
+            "identity_verification" => "identity_card",
+            "company_verification" => "certificate_of_incorporation",
+            "tax_verification" => "tax_document",
+            "articles_of_association" => "articles_of_association",
+            "shareholder_structure" => "certified_shareholder_structure",
+            "bank_verification" => "bank_statement",
+            "financial_statements" => "financial_statements",
+            "financial_verification" => "financial_verification",
+            "proof_of_principal_address" => "utility_bill",
+            "proof_of_legality" => "proof_of_legality",
+            "additional_document1" => "additional_document",
+            "additional_document2" => "additional_document",
+            "additional_document3" => "additional_document",
+        );
+
+        foreach ($expectedTypes as $field => $type) {
+            $this->assertArrayHasKey($field, $decoded, "documents.$field must serialize");
+            $this->assertSame($type, $decoded[$field]['type'], "documents.$field.type");
+            $this->assertSame("file_$field", $decoded[$field]['front'], "documents.$field.front");
+        }
+
+        // identity_verification is a Document (supports back); the others carry type + front only.
+        $this->assertSame("back_id", $decoded['identity_verification']['back']);
     }
 
     private function buildDocuments()
     {
-        $articles = new Document();
-        $articles->type = "articles_of_association";
-        $articles->front = "file_1";
-
-        $shareholder = new Document();
-        $shareholder->type = "certified_shareholder_structure";
-        $shareholder->front = "file_1";
-
-        $financialStatements = new Document();
-        $financialStatements->type = "financial_statements";
-        $financialStatements->front = "file_2";
-
-        $financialVerification = new Document();
-        $financialVerification->type = "financial_verification";
-        $financialVerification->front = "file_3";
-
         $documents = new OnboardSubEntityDocuments();
-        $documents->articles_of_association = $articles;
-        $documents->shareholder_structure = $shareholder;
-        $documents->financial_statements = $financialStatements;
-        $documents->financial_verification = $financialVerification;
+
+        $identity = new Document();
+        $identity->type = "identity_card";
+        $identity->front = "file_identity_verification";
+        $identity->back = "back_id";
+        $documents->identity_verification = $identity;
+
+        $companyVerification = new CompanyVerification();
+        $companyVerification->type = "certificate_of_incorporation";
+        $companyVerification->front = "file_company_verification";
+        $documents->company_verification = $companyVerification;
+
+        $taxVerification = new TaxVerification();
+        $taxVerification->type = "tax_document";
+        $taxVerification->front = "file_tax_verification";
+        $documents->tax_verification = $taxVerification;
+
+        $documents->articles_of_association = $this->document("articles_of_association", "articles_of_association");
+        $documents->shareholder_structure = $this->document("shareholder_structure", "certified_shareholder_structure");
+        $documents->bank_verification = $this->document("bank_verification", "bank_statement");
+        $documents->financial_statements = $this->document("financial_statements", "financial_statements");
+        $documents->financial_verification = $this->document("financial_verification", "financial_verification");
+        $documents->proof_of_principal_address = $this->document("proof_of_principal_address", "utility_bill");
+        $documents->proof_of_legality = $this->document("proof_of_legality", "proof_of_legality");
+        $documents->additional_document1 = $this->document("additional_document1", "additional_document");
+        $documents->additional_document2 = $this->document("additional_document2", "additional_document");
+        $documents->additional_document3 = $this->document("additional_document3", "additional_document");
 
         return $documents;
+    }
+
+    private function document($field, $type)
+    {
+        $document = new Document();
+        $document->type = $type;
+        $document->front = "file_$field";
+        return $document;
     }
 }

--- a/test/Checkout/Tests/Accounts/ProcessingDetailsSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/ProcessingDetailsSerializationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\ProcessingDetails;
+use Checkout\Accounts\ProcessingDetailsAch;
+use Checkout\Accounts\ProcessingDetailsPayments;
+use Checkout\Common\Country;
+use Checkout\Common\Currency;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class ProcessingDetailsSerializationTest extends TestCase
+{
+    public function testProcessingDetailsRoundTrip()
+    {
+        $ach = new ProcessingDetailsAch();
+        $ach->annual_ach_volume = 1000000;
+        $ach->average_ach_transaction_size = 5000;
+        $ach->estimated_monthly_credit_volume = 100000;
+        $ach->average_credit_amount = 4000;
+
+        $payments = new ProcessingDetailsPayments();
+        $payments->ach = $ach;
+
+        $processingDetails = new ProcessingDetails();
+        $processingDetails->annual_processing_volume = 2000000;
+        $processingDetails->average_transaction_value = 5000;
+        $processingDetails->average_order_fulfillment_time = 3;
+        $processingDetails->currency = Currency::$GBP;
+        $processingDetails->target_countries = array(Country::$GB);
+        $processingDetails->payments = $payments;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($processingDetails), true);
+
+        $this->assertSame(2000000, $decoded['annual_processing_volume']);
+        $this->assertSame(5000, $decoded['average_transaction_value']);
+        $this->assertSame(3, $decoded['average_order_fulfillment_time']);
+        $this->assertSame("GBP", $decoded['currency']);
+        $this->assertSame(array("GB"), $decoded['target_countries']);
+
+        $this->assertSame(1000000, $decoded['payments']['ach']['annual_ach_volume']);
+        $this->assertSame(5000, $decoded['payments']['ach']['average_ach_transaction_size']);
+        $this->assertSame(100000, $decoded['payments']['ach']['estimated_monthly_credit_volume']);
+        $this->assertSame(4000, $decoded['payments']['ach']['average_credit_amount']);
+    }
+}

--- a/test/Checkout/Tests/Accounts/ProcessingDetailsSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/ProcessingDetailsSerializationTest.php
@@ -27,7 +27,9 @@ class ProcessingDetailsSerializationTest extends TestCase
         $processingDetails->annual_processing_volume = 2000000;
         $processingDetails->average_transaction_value = 5000;
         $processingDetails->average_order_fulfillment_time = 3;
+        $processingDetails->highest_transaction_value = 25000;
         $processingDetails->currency = Currency::$GBP;
+        $processingDetails->settlement_country = Country::$GB;
         $processingDetails->target_countries = array(Country::$GB);
         $processingDetails->payments = $payments;
 
@@ -36,7 +38,9 @@ class ProcessingDetailsSerializationTest extends TestCase
         $this->assertSame(2000000, $decoded['annual_processing_volume']);
         $this->assertSame(5000, $decoded['average_transaction_value']);
         $this->assertSame(3, $decoded['average_order_fulfillment_time']);
+        $this->assertSame(25000, $decoded['highest_transaction_value']);
         $this->assertSame("GBP", $decoded['currency']);
+        $this->assertSame("GB", $decoded['settlement_country']);
         $this->assertSame(array("GB"), $decoded['target_countries']);
 
         $this->assertSame(1000000, $decoded['payments']['ach']['annual_ach_volume']);

--- a/test/Checkout/Tests/Accounts/RepresentativeIndividualSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/RepresentativeIndividualSerializationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\DateOfBirth;
+use Checkout\Accounts\PlaceOfBirth;
+use Checkout\Accounts\RepresentativeIndividual;
+use Checkout\Common\Address;
+use Checkout\Common\Country;
+use Checkout\Common\Phone;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class RepresentativeIndividualSerializationTest extends TestCase
+{
+    public function testRepresentativeIndividualRoundTrip()
+    {
+        $dateOfBirth = new DateOfBirth();
+        $dateOfBirth->day = 5;
+        $dateOfBirth->month = 6;
+        $dateOfBirth->year = 1996;
+
+        $placeOfBirth = new PlaceOfBirth();
+        $placeOfBirth->country = Country::$GB;
+
+        $address = new Address();
+        $address->address_line1 = "CheckoutSdk.com";
+        $address->city = "London";
+        $address->zip = "W1T 4TJ";
+        $address->country = Country::$GB;
+
+        $phone = new Phone();
+        $phone->country_code = "GB";
+        $phone->number = "2072343000";
+
+        $individual = new RepresentativeIndividual();
+        $individual->first_name = "John";
+        $individual->middle_name = "Robert";
+        $individual->last_name = "Representative";
+        $individual->date_of_birth = $dateOfBirth;
+        $individual->place_of_birth = $placeOfBirth;
+        $individual->national_id_number = "123456789";
+        $individual->email_address = "john@example.com";
+        $individual->phone = $phone;
+        $individual->address = $address;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($individual), true);
+
+        $this->assertSame("John", $decoded['first_name']);
+        $this->assertSame("Robert", $decoded['middle_name']);
+        $this->assertSame("Representative", $decoded['last_name']);
+        $this->assertSame("123456789", $decoded['national_id_number']);
+        $this->assertSame("john@example.com", $decoded['email_address']);
+        $this->assertSame(1996, $decoded['date_of_birth']['year']);
+        $this->assertSame("GB", $decoded['place_of_birth']['country']);
+        $this->assertSame("GB", $decoded['phone']['country_code']);
+        $this->assertSame("W1T 4TJ", $decoded['address']['zip']);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements and extensions to the Accounts API client and related data models to support Accounts API v3.0. The main goals are to enable schema version negotiation via the `Accept` header, expand the onboarding request and company models for new v3.0 fields, and add several new supporting classes for richer onboarding flows.

The most important changes are:

**Accounts API v3.0 Schema Versioning Support:**
- Added a `DEFAULT_SCHEMA_VERSION` constant and updated key client methods in `AccountsClient` to accept a `$schemaVersion` parameter (defaulting to 3.0), passing this as an `Accept` header to the API. This enables negotiation of the Accounts API schema version for all major entity operations. [[1]](diffhunk://#diff-f0889b85d23f6c93a7d2091a429c4a30751a6980f43e6f452a76682fc50786d5R28-R32) [[2]](diffhunk://#diff-f0889b85d23f6c93a7d2091a429c4a30751a6980f43e6f452a76682fc50786d5R44-R70) [[3]](diffhunk://#diff-f0889b85d23f6c93a7d2091a429c4a30751a6980f43e6f452a76682fc50786d5R90-R119) [[4]](diffhunk://#diff-f0889b85d23f6c93a7d2091a429c4a30751a6980f43e6f452a76682fc50786d5R392-R401) [[5]](diffhunk://#diff-61b617dd0619cfa0bb44a9288ca0f74f9d7bc9c4c5a48655a9943ffcea644b50R8-R21)

**Expanded Onboarding and Company Models:**
- Extended `OnboardEntityRequest` and `Company` with new fields required by Accounts API v3.0, such as `processing_details`, `agreed_terms`, `seller_category`, `is_draft`, `date_of_incorporation`, `regulatory_licence_number`, and more. Added detailed PHPDoc for each field. [[1]](diffhunk://#diff-8d41a24e3a4b64d88efc713a98498d6901a520028b71aa88208ce3c4a3cf8638R5-R92) [[2]](diffhunk://#diff-a5944cccdeb8d79f3bf7dac8d929ff869309702318b3a20acdd2ad3389a89294R7-R121)
- Added new business types in `BusinessType` and new entity roles in `EntityRoles` for v3.0 compatibility. [[1]](diffhunk://#diff-2a437fb73d4323b223b81661def2cb0220c8b00a1d4b34be7b0549aa27011963R7-R25) [[2]](diffhunk://#diff-60898761ef815f79fc85dbb779d91e45d6825d8b08af5fa6f0dc4aaab8f7650bR9-R11)

**New Supporting Data Classes for v3.0:**
- Introduced new classes for richer onboarding and processing details: `AgreedTerms`, `ProcessingDetails`, `ProcessingDetailsPayments`, `ProcessingDetailsAch`, `DateOfIncorporation`, and `CompanyPosition`. These enable capturing additional information required by the latest API version. [[1]](diffhunk://#diff-cacc03ec82984ef8cf1caaee340a749937dbf676b4d69bd939b3cb62447055c6R1-R51) [[2]](diffhunk://#diff-fc98e2e2812c357980f4668ae2ddbc730dd5cb1b89c996ed1b6afb2c77db7e04R1-R80) [[3]](diffhunk://#diff-30a3de2eb1d5b4c2df1397d4b068cd6b51646e230363f11601e54f1d39ab143fR1-R17) [[4]](diffhunk://#diff-b89cc49020797f05748facb52a724dea227a49345b67b452d6811d552346cf52R1-R45) [[5]](diffhunk://#diff-0694fe07982b79937c4c544b4620a2c275e7fc1b146bed3282b01d11ec2f4533R1-R36) [[6]](diffhunk://#diff-dc00c5859625c125f56fc1a8e7c4a53238284143fd4ca8773d6310bff41410d6R1-R18)

**OnboardSubEntityDocuments Enhancements:**
- Expanded `OnboardSubEntityDocuments` with new optional document fields (e.g., `articles_of_association`, `shareholder_structure`, `bank_verification`, etc.) to support the full set of required documents for different onboarding schema variants.

**Documentation and Header Handling Improvements:**
- Improved PHPDoc for all updated and new fields, clarifying requirements and formats. Enhanced `Headers` to support the new `accept` header for schema negotiation.

These changes collectively prepare the codebase for full support of Accounts API v3.0 onboarding and entity management, while maintaining backward compatibility.