### PR TITLE
feature/schemafix - Added missing fields for RepresentativeIndividual

### DIFF
--- a/lib/Checkout/Accounts/Citizenship.php
+++ b/lib/Checkout/Accounts/Citizenship.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Checkout\Accounts;
+
+/**
+ * A citizenship or legal status held by a company representative, as required by the
+ * Accounts API v3.0 individual schema.
+ */
+class Citizenship
+{
+    /**
+     * The type of citizenship or legal status (for example, "citizenship" or "residency").
+     * [Optional]
+     *
+     * @var string
+     */
+    public $type;
+
+    /**
+     * The two-letter ISO 3166-1 alpha-2 country code.
+     * [Required]
+     *
+     * @var string value of Country
+     */
+    public $country;
+}

--- a/lib/Checkout/Accounts/FinancialStatements.php
+++ b/lib/Checkout/Accounts/FinancialStatements.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class FinancialStatements
+{
+    /**
+     * @var string value of FinancialStatementsType
+     */
+    public $type;
+
+    /**
+     * @var string
+     */
+    public $front;
+}

--- a/lib/Checkout/Accounts/FinancialStatementsType.php
+++ b/lib/Checkout/Accounts/FinancialStatementsType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class FinancialStatementsType
+{
+    public static $financial_statements = "financial_statements";
+}

--- a/lib/Checkout/Accounts/NationalIdType.php
+++ b/lib/Checkout/Accounts/NationalIdType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Accounts;
+
+class NationalIdType
+{
+    public static $ssn = "ssn";
+    public static $itin = "itin";
+    public static $passport = "passport";
+    public static $driving_license = "driving_license";
+    public static $national_id_card = "national_id_card";
+    public static $residence_permit = "residence_permit";
+    public static $other = "other";
+}

--- a/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
+++ b/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
@@ -60,7 +60,7 @@ class OnboardSubEntityDocuments
      * Financial statements document.
      * [Optional]
      *
-     * @var Document
+     * @var FinancialStatements
      */
     public $financial_statements;
 

--- a/lib/Checkout/Accounts/RepresentativeIndividual.php
+++ b/lib/Checkout/Accounts/RepresentativeIndividual.php
@@ -55,6 +55,23 @@ class RepresentativeIndividual
     public $place_of_birth;
 
     /**
+     * The list of citizenships or legal statuses for the representative.
+     * [Required] (Accounts API v3.0)
+     *
+     * @var array values of Citizenship
+     */
+    public $citizenships;
+
+    /**
+     * The classification of the national identification number provided.
+     * [Required] (Accounts API v3.0)
+     * Enum: "ssn", "itin", "passport", "driving_license", "national_id_card", "residence_permit", "other"
+     *
+     * @var string value of NationalIdType
+     */
+    public $national_id_type;
+
+    /**
      * The representative's national identification number.
      * [Optional]
      * Format: region-specific (validated by the API against the sub-entity's country)

--- a/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
@@ -5,6 +5,8 @@ namespace Checkout\Tests\Accounts;
 use Checkout\Accounts\AgreedTerms;
 use Checkout\Accounts\CompanyVerification;
 use Checkout\Accounts\Document;
+use Checkout\Accounts\FinancialStatements;
+use Checkout\Accounts\FinancialStatementsType;
 use Checkout\Accounts\OnboardEntityRequest;
 use Checkout\Accounts\OnboardSubEntityDocuments;
 use Checkout\Accounts\TaxVerification;
@@ -92,7 +94,12 @@ class OnboardEntityRequestSerializationTest extends TestCase
         $documents->articles_of_association = $this->document("articles_of_association", "articles_of_association");
         $documents->shareholder_structure = $this->document("shareholder_structure", "certified_shareholder_structure");
         $documents->bank_verification = $this->document("bank_verification", "bank_statement");
-        $documents->financial_statements = $this->document("financial_statements", "financial_statements");
+
+        $financialStatements = new FinancialStatements();
+        $financialStatements->type = FinancialStatementsType::$financial_statements;
+        $financialStatements->front = "file_financial_statements";
+        $documents->financial_statements = $financialStatements;
+
         $documents->financial_verification = $this->document("financial_verification", "financial_verification");
         $documents->proof_of_principal_address = $this->document("proof_of_principal_address", "utility_bill");
         $documents->proof_of_legality = $this->document("proof_of_legality", "proof_of_legality");

--- a/test/Checkout/Tests/Accounts/RepresentativeIndividualSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/RepresentativeIndividualSerializationTest.php
@@ -2,7 +2,9 @@
 
 namespace Checkout\Tests\Accounts;
 
+use Checkout\Accounts\Citizenship;
 use Checkout\Accounts\DateOfBirth;
+use Checkout\Accounts\NationalIdType;
 use Checkout\Accounts\PlaceOfBirth;
 use Checkout\Accounts\RepresentativeIndividual;
 use Checkout\Common\Address;
@@ -33,12 +35,18 @@ class RepresentativeIndividualSerializationTest extends TestCase
         $phone->country_code = "GB";
         $phone->number = "2072343000";
 
+        $citizenship = new Citizenship();
+        $citizenship->type = "citizenship";
+        $citizenship->country = Country::$GB;
+
         $individual = new RepresentativeIndividual();
         $individual->first_name = "John";
         $individual->middle_name = "Robert";
         $individual->last_name = "Representative";
         $individual->date_of_birth = $dateOfBirth;
         $individual->place_of_birth = $placeOfBirth;
+        $individual->citizenships = array($citizenship);
+        $individual->national_id_type = NationalIdType::$ssn;
         $individual->national_id_number = "123456789";
         $individual->email_address = "john@example.com";
         $individual->phone = $phone;
@@ -49,6 +57,9 @@ class RepresentativeIndividualSerializationTest extends TestCase
         $this->assertSame("John", $decoded['first_name']);
         $this->assertSame("Robert", $decoded['middle_name']);
         $this->assertSame("Representative", $decoded['last_name']);
+        $this->assertSame("citizenship", $decoded['citizenships'][0]['type']);
+        $this->assertSame("GB", $decoded['citizenships'][0]['country']);
+        $this->assertSame("ssn", $decoded['national_id_type']);
         $this->assertSame("123456789", $decoded['national_id_number']);
         $this->assertSame("john@example.com", $decoded['email_address']);
         $this->assertSame(1996, $decoded['date_of_birth']['year']);


### PR DESCRIPTION
This pull request introduces support for new fields and types related to financial statements and individual representative information in the Accounts API v3.0. The main changes include adding models for citizenship, national ID types, and financial statements, updating the `RepresentativeIndividual` and `OnboardSubEntityDocuments` classes to use these new models, and enhancing test coverage to reflect these updates.

**Accounts API v3.0 Model Additions and Updates:**

* Added the `Citizenship` class to represent a representative's citizenship or legal status, and updated `RepresentativeIndividual` to include the `citizenships` array and `national_id_type` fields. [[1]](diffhunk://#diff-79701df8053370ab3c0f3451e410833536e3f90dfc547d76d604b3610796d879R1-R26) [[2]](diffhunk://#diff-1771f867d46d2a7c86fff4634b6f4cad8677a07ec59c6b045377a328295e82e6R57-R73)
* Added the `NationalIdType` class as an enum for various types of national identification numbers.
* Added the `FinancialStatements` class and `FinancialStatementsType` enum to model financial statements documents, and updated `OnboardSubEntityDocuments` to use `FinancialStatements` instead of `Document` for the `financial_statements` field. [[1]](diffhunk://#diff-cbb1aab61dbe46961a30ad8824afe0de5288d666730ef34c36eeb322cd1668bdR1-R16) [[2]](diffhunk://#diff-88ae33eb78591c5ff42d5a822ffad73c07da7385a604f445be39d318655cad7bR1-R8) [[3]](diffhunk://#diff-0d1b81258ffd45682b2cfebc61ac669f4602aa17c32a38e8985ad7b3645e2aa5L63-R63)

**Test Enhancements:**

* Updated `OnboardEntityRequestSerializationTest` to use the new `FinancialStatements` model in test data. [[1]](diffhunk://#diff-06b3d89a6e03ae5f33400da69ec46e0c4bbbb6d62100df34b0b280cfcdf72978R8-R9) [[2]](diffhunk://#diff-06b3d89a6e03ae5f33400da69ec46e0c4bbbb6d62100df34b0b280cfcdf72978L95-R102)
* Updated `RepresentativeIndividualSerializationTest` to test serialization and deserialization of the new `citizenships` and `national_id_type` fields. [[1]](diffhunk://#diff-947725dc6fa35f58893f08747f9d7a55ca668d0e7969b89558eaef67327859b9R5-R7) [[2]](diffhunk://#diff-947725dc6fa35f58893f08747f9d7a55ca668d0e7969b89558eaef67327859b9R38-R49) [[3]](diffhunk://#diff-947725dc6fa35f58893f08747f9d7a55ca668d0e7969b89558eaef67327859b9R60-R62)

These changes ensure the codebase is aligned with the Accounts API v3.0 schema and improve test coverage for the new and updated models.