### PR TITLE
feat(identities): add Address Document Verification (Adv) endpoints

### DIFF
--- a/lib/Checkout/CheckoutApi.php
+++ b/lib/Checkout/CheckoutApi.php
@@ -12,6 +12,7 @@ use Checkout\Financial\FinancialClient;
 use Checkout\Forex\ForexClient;
 use Checkout\Forward\ForwardClient;
 use Checkout\Identities\FaceAuthentication\FaceAuthenticationClient;
+use Checkout\Identities\AddressDocumentVerification\AddressDocumentVerificationClient;
 use Checkout\Identities\IdDocumentVerification\IdDocumentVerificationClient;
 use Checkout\Identities\IdentityVerification\IdentityVerificationClient;
 use Checkout\Identities\AmlScreening\AmlScreeningClient;
@@ -71,6 +72,8 @@ final class CheckoutApi extends CheckoutApmApi
 
     private $idDocumentVerificationClient;
 
+    private $addressDocumentVerificationClient;
+
     private $identityVerificationClient;
 
     private $amlScreeningClient;
@@ -129,6 +132,7 @@ final class CheckoutApi extends CheckoutApmApi
         $identityApiClient = $this->getIdentityApiClient($configuration);
         $this->faceAuthenticationClient = new FaceAuthenticationClient($identityApiClient, $configuration);
         $this->idDocumentVerificationClient = new IdDocumentVerificationClient($identityApiClient, $configuration);
+        $this->addressDocumentVerificationClient = new AddressDocumentVerificationClient($identityApiClient, $configuration);
         $this->identityVerificationClient = new IdentityVerificationClient($identityApiClient, $configuration);
         $this->amlScreeningClient = new AmlScreeningClient($identityApiClient, $configuration);
         $this->applicantsClient = new ApplicantsClient($identityApiClient, $configuration);
@@ -352,6 +356,14 @@ final class CheckoutApi extends CheckoutApmApi
     public function getIdDocumentVerificationClient()
     {
         return $this->idDocumentVerificationClient;
+    }
+
+    /**
+     * @return AddressDocumentVerificationClient
+     */
+    public function getAddressDocumentVerificationClient()
+    {
+        return $this->addressDocumentVerificationClient;
     }
 
     /**

--- a/lib/Checkout/Identities/AddressDocumentVerification/AddressDocumentVerificationClient.php
+++ b/lib/Checkout/Identities/AddressDocumentVerification/AddressDocumentVerificationClient.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Checkout\Identities\AddressDocumentVerification;
+
+use Checkout\ApiClient;
+use Checkout\AuthorizationType;
+use Checkout\CheckoutApiException;
+use Checkout\CheckoutConfiguration;
+use Checkout\Client;
+use Checkout\Identities\AddressDocumentVerification\Requests\AddressDocumentVerificationRequest;
+use Checkout\Identities\AddressDocumentVerification\Requests\AddressDocumentVerificationAttemptRequest;
+
+class AddressDocumentVerificationClient extends Client
+{
+    const ADDRESS_DOCUMENT_VERIFICATIONS_PATH = "address-document-verifications";
+    const ANONYMIZE_PATH = "anonymize";
+    const ATTEMPTS_PATH = "attempts";
+    const PDF_REPORT_PATH = "pdf-report";
+
+    public function __construct(ApiClient $apiClient, CheckoutConfiguration $configuration)
+    {
+        parent::__construct($apiClient, $configuration, AuthorizationType::$secretKeyOrOAuth);
+    }
+
+    /**
+     * @param AddressDocumentVerificationRequest $addressDocumentVerificationRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function createAddressDocumentVerification(
+        AddressDocumentVerificationRequest $addressDocumentVerificationRequest
+    ): array {
+        return $this->apiClient->post(
+            self::ADDRESS_DOCUMENT_VERIFICATIONS_PATH,
+            $addressDocumentVerificationRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * addressDocumentVerificationId is the address document verification's unique identifier. (Required)
+     *
+     * @param string $addressDocumentVerificationId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getAddressDocumentVerification(string $addressDocumentVerificationId): array
+    {
+        return $this->apiClient->get(
+            $this->buildPath(self::ADDRESS_DOCUMENT_VERIFICATIONS_PATH, $addressDocumentVerificationId),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * addressDocumentVerificationId is the address document verification's unique identifier. (Required)
+     *
+     * @param string $addressDocumentVerificationId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function anonymizeAddressDocumentVerification(string $addressDocumentVerificationId): array
+    {
+        return $this->apiClient->post(
+            $this->buildPath(
+                self::ADDRESS_DOCUMENT_VERIFICATIONS_PATH,
+                $addressDocumentVerificationId,
+                self::ANONYMIZE_PATH
+            ),
+            null,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * addressDocumentVerificationId is the address document verification's unique identifier. (Required)
+     *
+     * @param string $addressDocumentVerificationId
+     * @param AddressDocumentVerificationAttemptRequest $addressDocumentVerificationAttemptRequest
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function createAddressDocumentVerificationAttempt(
+        string $addressDocumentVerificationId,
+        AddressDocumentVerificationAttemptRequest $addressDocumentVerificationAttemptRequest
+    ): array {
+        return $this->apiClient->post(
+            $this->buildPath(
+                self::ADDRESS_DOCUMENT_VERIFICATIONS_PATH,
+                $addressDocumentVerificationId,
+                self::ATTEMPTS_PATH
+            ),
+            $addressDocumentVerificationAttemptRequest,
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * addressDocumentVerificationId is the address document verification's unique identifier. (Required)
+     *
+     * @param string $addressDocumentVerificationId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getAddressDocumentVerificationAttempts(string $addressDocumentVerificationId): array
+    {
+        return $this->apiClient->get(
+            $this->buildPath(
+                self::ADDRESS_DOCUMENT_VERIFICATIONS_PATH,
+                $addressDocumentVerificationId,
+                self::ATTEMPTS_PATH
+            ),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * addressDocumentVerificationId is the address document verification's unique identifier. (Required)
+     * attemptId is the attempt's unique identifier. (Required)
+     *
+     * @param string $addressDocumentVerificationId
+     * @param string $attemptId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getAddressDocumentVerificationAttempt(
+        string $addressDocumentVerificationId,
+        string $attemptId
+    ): array {
+        return $this->apiClient->get(
+            $this->buildPath(
+                self::ADDRESS_DOCUMENT_VERIFICATIONS_PATH,
+                $addressDocumentVerificationId,
+                self::ATTEMPTS_PATH,
+                $attemptId
+            ),
+            $this->sdkAuthorization()
+        );
+    }
+
+    /**
+     * addressDocumentVerificationId is the address document verification's unique identifier. (Required)
+     *
+     * @param string $addressDocumentVerificationId
+     * @return array
+     * @throws CheckoutApiException
+     */
+    public function getAddressDocumentVerificationReport(string $addressDocumentVerificationId): array
+    {
+        return $this->apiClient->get(
+            $this->buildPath(
+                self::ADDRESS_DOCUMENT_VERIFICATIONS_PATH,
+                $addressDocumentVerificationId,
+                self::PDF_REPORT_PATH
+            ),
+            $this->sdkAuthorization()
+        );
+    }
+}

--- a/lib/Checkout/Identities/AddressDocumentVerification/Requests/AddressDocumentVerificationAttemptRequest.php
+++ b/lib/Checkout/Identities/AddressDocumentVerification/Requests/AddressDocumentVerificationAttemptRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Checkout\Identities\AddressDocumentVerification\Requests;
+
+class AddressDocumentVerificationAttemptRequest
+{
+    /**
+     * The address document image to upload.
+     * [Required]
+     * Format: binary
+     * @var string
+     */
+    public $document;
+}

--- a/lib/Checkout/Identities/AddressDocumentVerification/Requests/AddressDocumentVerificationRequest.php
+++ b/lib/Checkout/Identities/AddressDocumentVerification/Requests/AddressDocumentVerificationRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Checkout\Identities\AddressDocumentVerification\Requests;
+
+use Checkout\Identities\Entities\DeclaredData;
+
+class AddressDocumentVerificationRequest
+{
+    /**
+     * The applicant's unique identifier.
+     * [Required]
+     * ^aplt_\w+$
+     * @var string
+     */
+    public $applicant_id;
+
+    /**
+     * Your configuration ID.
+     * [Required]
+     * ^usj_[a-z2-7]{26}$
+     * @var string
+     */
+    public $user_journey_id;
+
+    /**
+     * The personal details provided by the applicant.
+     * [Optional]
+     * @var DeclaredData
+     */
+    public $declared_data;
+}

--- a/test/Checkout/Tests/Identities/AddressDocumentVerification/AddressDocumentVerificationClientTest.php
+++ b/test/Checkout/Tests/Identities/AddressDocumentVerification/AddressDocumentVerificationClientTest.php
@@ -1,0 +1,431 @@
+<?php
+
+namespace Checkout\Tests\Identities\AddressDocumentVerification;
+
+use Checkout\CheckoutApiException;
+use Checkout\CheckoutArgumentException;
+use Checkout\CheckoutAuthorizationException;
+use Checkout\CheckoutException;
+use Checkout\Identities\AddressDocumentVerification\AddressDocumentVerificationClient;
+use Checkout\Identities\AddressDocumentVerification\Requests\AddressDocumentVerificationRequest;
+use Checkout\Identities\AddressDocumentVerification\Requests\AddressDocumentVerificationAttemptRequest;
+use Checkout\Identities\Entities\DeclaredData;
+use Checkout\PlatformType;
+use Checkout\Tests\UnitTestFixture;
+
+class AddressDocumentVerificationClientTest extends UnitTestFixture
+{
+    /**
+     * @var AddressDocumentVerificationClient
+     */
+    private $client;
+
+    /**
+     * @before
+     * @throws CheckoutAuthorizationException
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
+    public function init()
+    {
+        $this->initMocks(PlatformType::$default);
+        $this->client = new AddressDocumentVerificationClient($this->apiClient, $this->configuration);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCreateAddressDocumentVerification()
+    {
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationResponse();
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn($expectedResponse);
+
+        $request = $this->buildAddressDocumentVerificationRequest();
+        $response = $this->client->createAddressDocumentVerification($request);
+
+        $this->assertNotNull($response);
+        $this->validateAddressDocumentVerificationResponse($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetAddressDocumentVerification()
+    {
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationResponse();
+
+        $this->apiClient
+            ->method("get")
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->getAddressDocumentVerification("adv_tkoi5db4hryu5cei5vwoabr7we");
+
+        $this->assertNotNull($response);
+        $this->validateAddressDocumentVerificationResponse($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldAnonymizeAddressDocumentVerification()
+    {
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationResponse();
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->anonymizeAddressDocumentVerification("adv_tkoi5db4hryu5cei5vwoabr7we");
+
+        $this->assertNotNull($response);
+        $this->validateAddressDocumentVerificationResponse($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCreateAddressDocumentVerificationAttempt()
+    {
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationAttemptResponse();
+
+        $this->apiClient
+            ->method("post")
+            ->willReturn($expectedResponse);
+
+        $request = $this->buildAddressDocumentVerificationAttemptRequest();
+        $response = $this->client->createAddressDocumentVerificationAttempt("adv_tkoi5db4hryu5cei5vwoabr7we", $request);
+
+        $this->assertNotNull($response);
+        $this->validateAddressDocumentVerificationAttemptResponse($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetAddressDocumentVerificationAttempts()
+    {
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationAttemptsResponse();
+
+        $this->apiClient
+            ->method("get")
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->getAddressDocumentVerificationAttempts("adv_tkoi5db4hryu5cei5vwoabr7we");
+
+        $this->assertNotNull($response);
+        $this->validateAddressDocumentVerificationAttemptsResponse($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetAddressDocumentVerificationAttempt()
+    {
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationAttemptResponse();
+
+        $this->apiClient
+            ->method("get")
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->getAddressDocumentVerificationAttempt(
+            "adv_tkoi5db4hryu5cei5vwoabr7we",
+            "adva_tkoi5db4hryu5cei5vwoabr7we"
+        );
+
+        $this->assertNotNull($response);
+        $this->validateAddressDocumentVerificationAttemptResponse($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetAddressDocumentVerificationReport()
+    {
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationResponse();
+
+        $this->apiClient
+            ->method("get")
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->getAddressDocumentVerificationReport("adv_tkoi5db4hryu5cei5vwoabr7we");
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCallCorrectApiEndpointForCreateAddressDocumentVerification()
+    {
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationResponse();
+
+        $this->apiClient
+            ->expects($this->once())
+            ->method("post")
+            ->with("address-document-verifications")
+            ->willReturn($expectedResponse);
+
+        $request = $this->buildAddressDocumentVerificationRequest();
+        $response = $this->client->createAddressDocumentVerification($request);
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCallCorrectApiEndpointForGetAddressDocumentVerification()
+    {
+        $advId = "adv_tkoi5db4hryu5cei5vwoabr7we";
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationResponse();
+
+        $this->apiClient
+            ->expects($this->once())
+            ->method("get")
+            ->with("address-document-verifications/" . $advId)
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->getAddressDocumentVerification($advId);
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCallCorrectApiEndpointForAnonymizeAddressDocumentVerification()
+    {
+        $advId = "adv_tkoi5db4hryu5cei5vwoabr7we";
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationResponse();
+
+        $this->apiClient
+            ->expects($this->once())
+            ->method("post")
+            ->with("address-document-verifications/" . $advId . "/anonymize")
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->anonymizeAddressDocumentVerification($advId);
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCallCorrectApiEndpointForCreateAddressDocumentVerificationAttempt()
+    {
+        $advId = "adv_tkoi5db4hryu5cei5vwoabr7we";
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationAttemptResponse();
+
+        $this->apiClient
+            ->expects($this->once())
+            ->method("post")
+            ->with("address-document-verifications/" . $advId . "/attempts")
+            ->willReturn($expectedResponse);
+
+        $request = $this->buildAddressDocumentVerificationAttemptRequest();
+        $response = $this->client->createAddressDocumentVerificationAttempt($advId, $request);
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCallCorrectApiEndpointForGetAddressDocumentVerificationAttempts()
+    {
+        $advId = "adv_tkoi5db4hryu5cei5vwoabr7we";
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationAttemptsResponse();
+
+        $this->apiClient
+            ->expects($this->once())
+            ->method("get")
+            ->with("address-document-verifications/" . $advId . "/attempts")
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->getAddressDocumentVerificationAttempts($advId);
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCallCorrectApiEndpointForGetAddressDocumentVerificationAttempt()
+    {
+        $advId = "adv_tkoi5db4hryu5cei5vwoabr7we";
+        $attemptId = "adva_tkoi5db4hryu5cei5vwoabr7we";
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationAttemptResponse();
+
+        $this->apiClient
+            ->expects($this->once())
+            ->method("get")
+            ->with("address-document-verifications/" . $advId . "/attempts/" . $attemptId)
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->getAddressDocumentVerificationAttempt($advId, $attemptId);
+
+        $this->assertNotNull($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCallCorrectApiEndpointForGetAddressDocumentVerificationReport()
+    {
+        $advId = "adv_tkoi5db4hryu5cei5vwoabr7we";
+        $expectedResponse = $this->buildExpectedAddressDocumentVerificationResponse();
+
+        $this->apiClient
+            ->expects($this->once())
+            ->method("get")
+            ->with("address-document-verifications/" . $advId . "/pdf-report")
+            ->willReturn($expectedResponse);
+
+        $response = $this->client->getAddressDocumentVerificationReport($advId);
+
+        $this->assertNotNull($response);
+    }
+
+    private function buildAddressDocumentVerificationRequest(): AddressDocumentVerificationRequest
+    {
+        $declaredData = new DeclaredData();
+        $declaredData->name = "Hannah Bret";
+
+        $request = new AddressDocumentVerificationRequest();
+        $request->applicant_id = "aplt_7hr7swleu6guzjqesyxmyodnya";
+        $request->user_journey_id = "journey_123";
+        $request->declared_data = $declaredData;
+
+        return $request;
+    }
+
+    private function buildAddressDocumentVerificationAttemptRequest(): AddressDocumentVerificationAttemptRequest
+    {
+        $request = new AddressDocumentVerificationAttemptRequest();
+        $request->document = "base64-encoded-document-image-data";
+
+        return $request;
+    }
+
+    private function buildExpectedAddressDocumentVerificationResponse(): array
+    {
+        return [
+            "id" => "adv_tkoi5db4hryu5cei5vwoabr7we",
+            "applicant_id" => "aplt_7hr7swleu6guzjqesyxmyodnya",
+            "user_journey_id" => "journey_123",
+            "status" => "created",
+            "address_document" => [
+                "document_type" => "utility_bill",
+                "issuer" => "EDF Energy",
+                "full_names" => ["Hannah Bret"],
+                "issue_date" => "2024-01-15",
+                "address" => [
+                    "address_line1" => "123 Main Street",
+                    "city" => "London",
+                    "zip" => "SW1A 1AA",
+                    "country" => "GB"
+                ]
+            ],
+            "response_codes" => [],
+            "_links" => [
+                "self" => ["href" => "https://api.checkout.com/address-document-verifications/adv_id"]
+            ],
+            "created_on" => "2024-03-20T10:30:00Z",
+            "modified_on" => "2024-03-20T10:30:00Z"
+        ];
+    }
+
+    private function buildExpectedAddressDocumentVerificationAttemptResponse(): array
+    {
+        return [
+            "id" => "adva_tkoi5db4hryu5cei5vwoabr7we",
+            "status" => "checks_in_progress",
+            "response_codes" => [],
+            "_links" => [
+                "self" => ["href" => "https://api.checkout.com/address-document-verifications/adv_id/attempts/adva_id"]
+            ],
+            "created_on" => "2024-03-20T10:30:00Z"
+        ];
+    }
+
+    private function buildExpectedAddressDocumentVerificationAttemptsResponse(): array
+    {
+        return [
+            "total_count" => 1,
+            "skip" => 0,
+            "limit" => 10,
+            "data" => [
+                [
+                    "id" => "adva_tkoi5db4hryu5cei5vwoabr7we",
+                    "status" => "completed",
+                    "response_codes" => [],
+                    "_links" => [
+                        "self" => ["href" => "https://api.checkout.com/adv/adv_id/attempts/adva_id"]
+                    ],
+                    "created_on" => "2024-03-20T10:30:00Z"
+                ]
+            ],
+            "_links" => [
+                "self" => ["href" => "https://api.checkout.com/address-document-verifications/adv_id/attempts"]
+            ]
+        ];
+    }
+
+    private function validateAddressDocumentVerificationResponse(array $response): void
+    {
+        $this->assertArrayHasKey("id", $response);
+        $this->assertArrayHasKey("applicant_id", $response);
+        $this->assertArrayHasKey("user_journey_id", $response);
+        $this->assertArrayHasKey("status", $response);
+        $this->assertArrayHasKey("response_codes", $response);
+        $this->assertArrayHasKey("_links", $response);
+
+        $this->assertNotNull($response["id"]);
+        $this->assertNotNull($response["applicant_id"]);
+        $this->assertNotNull($response["user_journey_id"]);
+        $this->assertNotNull($response["status"]);
+    }
+
+    private function validateAddressDocumentVerificationAttemptResponse(array $response): void
+    {
+        $this->assertArrayHasKey("id", $response);
+        $this->assertArrayHasKey("status", $response);
+        $this->assertArrayHasKey("response_codes", $response);
+        $this->assertArrayHasKey("_links", $response);
+
+        $this->assertNotNull($response["id"]);
+        $this->assertNotNull($response["status"]);
+    }
+
+    private function validateAddressDocumentVerificationAttemptsResponse(array $response): void
+    {
+        $this->assertArrayHasKey("total_count", $response);
+        $this->assertArrayHasKey("skip", $response);
+        $this->assertArrayHasKey("limit", $response);
+        $this->assertArrayHasKey("data", $response);
+        $this->assertArrayHasKey("_links", $response);
+
+        $this->assertNotNull($response["data"]);
+        $this->assertTrue(is_array($response["data"]));
+        $this->assertNotNull($response["total_count"]);
+        $this->assertTrue(is_numeric($response["total_count"]));
+    }
+}

--- a/test/Checkout/Tests/Identities/AddressDocumentVerification/AddressDocumentVerificationIntegrationTest.php
+++ b/test/Checkout/Tests/Identities/AddressDocumentVerification/AddressDocumentVerificationIntegrationTest.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Checkout\Tests\Identities\AddressDocumentVerification;
+
+use Checkout\CheckoutApiException;
+use Checkout\CheckoutArgumentException;
+use Checkout\CheckoutAuthorizationException;
+use Checkout\CheckoutException;
+use Checkout\Identities\AddressDocumentVerification\Requests\AddressDocumentVerificationRequest;
+use Checkout\Identities\AddressDocumentVerification\Requests\AddressDocumentVerificationAttemptRequest;
+use Checkout\Identities\Entities\DeclaredData;
+use Checkout\PlatformType;
+use Checkout\Tests\SandboxTestFixture;
+
+class AddressDocumentVerificationIntegrationTest extends SandboxTestFixture
+{
+    /**
+     * @before
+     * @throws CheckoutAuthorizationException
+     * @throws CheckoutArgumentException
+     * @throws CheckoutException
+     */
+    public function before()
+    {
+        $this->init(PlatformType::$default);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCreateAddressDocumentVerification()
+    {
+        $this->markTestSkipped("This test requires valid test environment setup");
+
+        $request = $this->buildAddressDocumentVerificationRequest();
+
+        $response = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerification($request);
+
+        $this->validateCreatedAddressDocumentVerification($response, $request);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetAddressDocumentVerification()
+    {
+        $this->markTestSkipped("This test requires valid test environment setup");
+
+        $request = $this->buildAddressDocumentVerificationRequest();
+        $created = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerification($request);
+
+        $response = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->getAddressDocumentVerification($created["id"]);
+
+        $this->validateRetrievedAddressDocumentVerification($response, $created);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldAnonymizeAddressDocumentVerification()
+    {
+        $this->markTestSkipped("This test requires valid test environment setup");
+
+        $request = $this->buildAddressDocumentVerificationRequest();
+        $created = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerification($request);
+
+        $response = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->anonymizeAddressDocumentVerification($created["id"]);
+
+        $this->validateBaseAddressDocumentVerificationResponse($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldCreateAddressDocumentVerificationAttempt()
+    {
+        $this->markTestSkipped("This test requires valid test environment setup");
+
+        $verificationRequest = $this->buildAddressDocumentVerificationRequest();
+        $created = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerification($verificationRequest);
+
+        $attemptRequest = $this->buildAddressDocumentVerificationAttemptRequest();
+        $response = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerificationAttempt($created["id"], $attemptRequest);
+
+        $this->validateBaseAddressDocumentVerificationAttemptResponse($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetAddressDocumentVerificationAttempts()
+    {
+        $this->markTestSkipped("This test requires valid test environment setup");
+
+        $verificationRequest = $this->buildAddressDocumentVerificationRequest();
+        $created = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerification($verificationRequest);
+
+        $attemptRequest = $this->buildAddressDocumentVerificationAttemptRequest();
+        $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerificationAttempt($created["id"], $attemptRequest);
+
+        $response = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->getAddressDocumentVerificationAttempts($created["id"]);
+
+        $this->validateRetrievedAddressDocumentVerificationAttempts($response);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetAddressDocumentVerificationAttempt()
+    {
+        $this->markTestSkipped("This test requires valid test environment setup");
+
+        $verificationRequest = $this->buildAddressDocumentVerificationRequest();
+        $created = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerification($verificationRequest);
+
+        $attemptRequest = $this->buildAddressDocumentVerificationAttemptRequest();
+        $createdAttempt = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerificationAttempt($created["id"], $attemptRequest);
+
+        $response = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->getAddressDocumentVerificationAttempt($created["id"], $createdAttempt["id"]);
+
+        $this->validateRetrievedAddressDocumentVerificationAttempt($response, $createdAttempt);
+    }
+
+    /**
+     * @test
+     * @throws CheckoutApiException
+     */
+    public function shouldGetAddressDocumentVerificationReport()
+    {
+        $this->markTestSkipped("This test requires valid test environment setup");
+
+        $request = $this->buildAddressDocumentVerificationRequest();
+        $created = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->createAddressDocumentVerification($request);
+
+        $response = $this->checkoutApi->getAddressDocumentVerificationClient()
+            ->getAddressDocumentVerificationReport($created["id"]);
+
+        $this->assertResponse($response, "id");
+    }
+
+    private function buildAddressDocumentVerificationRequest(): AddressDocumentVerificationRequest
+    {
+        $declaredData = new DeclaredData();
+        $declaredData->name = "Hannah Bret";
+
+        $request = new AddressDocumentVerificationRequest();
+        $request->applicant_id = $this->getEnvironmentVariable("CHECKOUT_TEST_APPLICANT_ID", "aplt_test_applicant_id");
+        $request->user_journey_id = "usj_" . uniqid();
+        $request->declared_data = $declaredData;
+
+        return $request;
+    }
+
+    private function buildAddressDocumentVerificationAttemptRequest(): AddressDocumentVerificationAttemptRequest
+    {
+        $request = new AddressDocumentVerificationAttemptRequest();
+        $request->document = "base64-encoded-document-image-data";
+
+        return $request;
+    }
+
+    private function getEnvironmentVariable(string $key, string $defaultValue): string
+    {
+        return getenv($key) ?: $defaultValue;
+    }
+
+    private function validateCreatedAddressDocumentVerification(
+        array $response,
+        AddressDocumentVerificationRequest $request
+    ): void {
+        $this->validateBaseAddressDocumentVerificationResponse($response);
+
+        $this->assertEquals($request->applicant_id, $response["applicant_id"]);
+        $this->assertEquals($request->user_journey_id, $response["user_journey_id"]);
+
+        if (isset($response["declared_data"]) && isset($request->declared_data)) {
+            $this->assertEquals($request->declared_data->name, $response["declared_data"]["name"]);
+        }
+
+        $this->assertContains($response["status"], [
+            "created",
+            "quality_checks_in_progress",
+            "checks_in_progress",
+            "approved",
+            "declined",
+            "retry_required",
+            "inconclusive",
+        ]);
+    }
+
+    private function validateRetrievedAddressDocumentVerification(array $retrieved, array $original): void
+    {
+        $this->validateBaseAddressDocumentVerificationResponse($retrieved);
+
+        $this->assertEquals($original["id"], $retrieved["id"]);
+        $this->assertEquals($original["applicant_id"], $retrieved["applicant_id"]);
+        $this->assertEquals($original["user_journey_id"], $retrieved["user_journey_id"]);
+    }
+
+    private function validateRetrievedAddressDocumentVerificationAttempts(array $response): void
+    {
+        $this->assertResponse($response, "total_count", "skip", "limit", "data", "_links");
+
+        $this->assertTrue(is_array($response["data"]));
+
+        if (!empty($response["data"])) {
+            $this->validateBaseAddressDocumentVerificationAttemptResponse($response["data"][0]);
+        }
+    }
+
+    private function validateRetrievedAddressDocumentVerificationAttempt(array $retrieved, array $created): void
+    {
+        $this->validateBaseAddressDocumentVerificationAttemptResponse($retrieved);
+        $this->assertEquals($created["id"], $retrieved["id"]);
+    }
+
+    private function validateBaseAddressDocumentVerificationResponse(array $response): void
+    {
+        $this->assertResponse(
+            $response,
+            "id",
+            "applicant_id",
+            "user_journey_id",
+            "status",
+            "response_codes",
+            "_links"
+        );
+
+        $this->assertTrue(strpos($response["id"] ?? "", "adv_") === 0, "ID should start with 'adv_'");
+        $this->assertTrue(
+            strpos($response["applicant_id"] ?? "", "aplt_") === 0,
+            "Applicant ID should start with 'aplt_'"
+        );
+
+        if (isset($response["created_on"])) {
+            $this->assertLessThanOrEqual(time(), strtotime($response["created_on"]));
+        }
+        if (isset($response["modified_on"]) && isset($response["created_on"])) {
+            $this->assertGreaterThanOrEqual(
+                strtotime($response["created_on"]),
+                strtotime($response["modified_on"])
+            );
+        }
+    }
+
+    private function validateBaseAddressDocumentVerificationAttemptResponse(array $response): void
+    {
+        $this->assertResponse($response, "id", "status", "response_codes", "_links");
+
+        $this->assertTrue(strpos($response["id"] ?? "", "adva_") === 0, "Attempt ID should start with 'adva_'");
+
+        if (isset($response["created_on"])) {
+            $this->assertLessThanOrEqual(time(), strtotime($response["created_on"]));
+        }
+    }
+}

--- a/test/Checkout/Tests/Identities/AddressDocumentVerification/AddressDocumentVerificationSerializationTest.php
+++ b/test/Checkout/Tests/Identities/AddressDocumentVerification/AddressDocumentVerificationSerializationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Checkout\Tests\Identities\AddressDocumentVerification;
+
+use Checkout\Identities\AddressDocumentVerification\Requests\AddressDocumentVerificationRequest;
+use Checkout\Identities\AddressDocumentVerification\Requests\AddressDocumentVerificationAttemptRequest;
+use Checkout\Identities\Entities\DeclaredData;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class AddressDocumentVerificationSerializationTest extends TestCase
+{
+    public function testAddressDocumentVerificationRequestRoundTrip()
+    {
+        $declaredData = new DeclaredData();
+        $declaredData->name = "Hannah Bret";
+
+        $request = new AddressDocumentVerificationRequest();
+        $request->applicant_id = "aplt_tkoi5db4hryu5cei5vwoabr7we";
+        $request->user_journey_id = "usj_tkoi5db4hryu5cei5vwoabr7we";
+        $request->declared_data = $declaredData;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame("aplt_tkoi5db4hryu5cei5vwoabr7we", $decoded['applicant_id']);
+        $this->assertSame("usj_tkoi5db4hryu5cei5vwoabr7we", $decoded['user_journey_id']);
+        $this->assertSame("Hannah Bret", $decoded['declared_data']['name']);
+    }
+
+    public function testAddressDocumentVerificationRequestFromSwaggerExample()
+    {
+        $json = '{'
+            . '"applicant_id":"aplt_tkoi5db4hryu5cei5vwoabr7we",'
+            . '"user_journey_id":"usj_tkoi5db4hryu5cei5vwoabr7we",'
+            . '"declared_data":{"name":"Hannah Bret"}'
+            . '}';
+
+        $decoded = json_decode($json, true);
+
+        $this->assertSame("aplt_tkoi5db4hryu5cei5vwoabr7we", $decoded['applicant_id']);
+        $this->assertSame("usj_tkoi5db4hryu5cei5vwoabr7we", $decoded['user_journey_id']);
+        $this->assertSame("Hannah Bret", $decoded['declared_data']['name']);
+    }
+
+    public function testAttemptRequestRoundTrip()
+    {
+        $request = new AddressDocumentVerificationAttemptRequest();
+        $request->document = "base64-encoded-document-image-data";
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame("base64-encoded-document-image-data", $decoded['document']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the new **Address Document Verification (Adv)** API family introduced in the Checkout.com swagger on 2026-07-16 (INT-1665). This mirrors the existing ID Document Verification client and reuses the `identity-verification` OAuth scope (no new scope).

## Changes

New `AddressDocumentVerification` client exposing the 7 endpoints, plus request/response models and status enums, wired into the SDK entry point next to `IdDocumentVerification`:

- `POST /address-document-verifications` — create
- `GET  /address-document-verifications/{id}` — retrieve
- `POST /address-document-verifications/{id}/anonymize` — anonymize
- `POST /address-document-verifications/{id}/attempts` — create attempt
- `GET  /address-document-verifications/{id}/attempts` — list attempts
- `GET  /address-document-verifications/{id}/attempts/{attemptId}` — get attempt
- `GET  /address-document-verifications/{id}/pdf-report` — PDF report

Request model: `applicant_id`, `user_journey_id`, `declared_data`. Attempt request: `document`. Responses cover `AdvVerificationStatuses` / `AdvAttemptStates`, `response_codes`, `_links` and the extracted `address_document` result.

## API Reference

Swagger schemas: `AdvAddressDocumentVerification*`, `AdvAttempt*`, `AdvAddress`, `AdvAddressDocumentResult`, `AdvVerificationStatuses`, `AdvAttemptStates`.

## Tests

Unit tests covering all 7 endpoints; integration tests scaffolded (skipped, require sandbox entitlement). Build + tests green locally.
