### PR TITLE
feat: add InstrumentDocumentType with bank_statement

### DIFF
--- a/lib/Checkout/Accounts/InstrumentDocument.php
+++ b/lib/Checkout/Accounts/InstrumentDocument.php
@@ -5,7 +5,10 @@ namespace Checkout\Accounts;
 class InstrumentDocument
 {
     /**
-     * @var string
+     * The document type. For a bank account instrument the API accepts only
+     * InstrumentDocumentType::$bank_statement, which is also the default.
+     *
+     * @var string value of InstrumentDocumentType
      */
     public $type;
 

--- a/lib/Checkout/Accounts/InstrumentDocumentType.php
+++ b/lib/Checkout/Accounts/InstrumentDocumentType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Checkout\Accounts;
+
+/**
+ * The document type accepted by InstrumentDocument, the legal document used to verify a bank
+ * account when creating a payment instrument.
+ *
+ * Deliberately separate from Checkout\Common\DocumentType: that one lists identity documents
+ * (passport, national identity card, driving license), and the API keeps the bank account
+ * document type as its own enum, whose only accepted value is bank_statement. Offering
+ * bank_statement alongside the identity documents would suggest it is valid where the API
+ * rejects it, and the reverse.
+ */
+class InstrumentDocumentType
+{
+    public static $bank_statement = "bank_statement";
+}

--- a/test/Checkout/Tests/Accounts/InstrumentDocumentTypeTest.php
+++ b/test/Checkout/Tests/Accounts/InstrumentDocumentTypeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\InstrumentDocument;
+use Checkout\Accounts\InstrumentDocumentType;
+use Checkout\Common\DocumentType;
+use Checkout\Tests\UnitTestFixture;
+
+class InstrumentDocumentTypeTest extends UnitTestFixture
+{
+    /**
+     * @test
+     */
+    public function shouldExposeBankStatementForInstrumentDocuments()
+    {
+        $document = new InstrumentDocument();
+        $document->type = InstrumentDocumentType::$bank_statement;
+        $document->file_id = "file_wxglze3wwywujg4nna5fb7ldli";
+
+        $this->assertEquals("bank_statement", $document->type);
+    }
+
+    /**
+     * bank_statement belongs to the instrument document enum, not to the identity document one.
+     * The API keeps them separate, and this test is what stops them being merged again the next
+     * time someone reports the value as missing from DocumentType.
+     *
+     * @test
+     */
+    public function shouldKeepBankStatementOutOfTheIdentityDocumentType()
+    {
+        $identityTypes = [
+            DocumentType::$passport,
+            DocumentType::$national_identity_card,
+            DocumentType::$driving_license,
+            DocumentType::$citizen_card,
+            DocumentType::$residence_permit,
+            DocumentType::$electoral_id,
+        ];
+
+        $this->assertNotContains("bank_statement", $identityTypes);
+    }
+}


### PR DESCRIPTION
## What

Adds `InstrumentDocumentType` with the single value `bank_statement`, the document type for the bank account behind a platforms payment instrument.

Reported internally: the value is documented in the API reference but missing from the SDK, and it is blocking a merchant. Verified against the spec, where that document type is a single-value enum whose only accepted value (and default) is `bank_statement`.

## Why a separate type instead of adding the value to the existing document type

The existing document type lists identity documents (passport, national identity card, driving license) and is used for entity onboarding. The API models the bank account document type as its own enum. Adding `bank_statement` alongside the identity values would offer it in every place the API rejects it, and would equally suggest the identity values are accepted on an instrument document, where they are not.

## Tests

One of the tests asserts `bank_statement` is **not** in the identity document type. That is deliberate: it is what stops the two being merged the next time someone reports the value as missing from the identity enum.

## Not breaking

Purely additive. No existing constant, field or signature changes.

Refs INT-1691.