### PR TITLE
feat: model the onboarding bank, articles and shareholder documents

### DIFF
--- a/lib/Checkout/Accounts/ArticlesOfAssociation.php
+++ b/lib/Checkout/Accounts/ArticlesOfAssociation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Checkout\Accounts;
+
+/**
+ * Memorandum or articles of association document.
+ */
+class ArticlesOfAssociation
+{
+    /**
+     * @var string value of ArticlesOfAssociationType
+     */
+    public $type;
+
+    /**
+     * @var string the ID of the front side of the document, as returned when the file was uploaded
+     */
+    public $front;
+}

--- a/lib/Checkout/Accounts/ArticlesOfAssociationType.php
+++ b/lib/Checkout/Accounts/ArticlesOfAssociationType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Checkout\Accounts;
+
+/**
+ * The document type accepted as the memorandum or articles of association when onboarding
+ * a sub-entity.
+ *
+ * Separate from Common\DocumentType, which lists identity documents.
+ */
+class ArticlesOfAssociationType
+{
+    public static $memorandum_of_association = "memorandum_of_association";
+    public static $articles_of_association = "articles_of_association";
+}

--- a/lib/Checkout/Accounts/BankVerification.php
+++ b/lib/Checkout/Accounts/BankVerification.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Checkout\Accounts;
+
+/**
+ * A document showing transactions from the last 3 months.
+ */
+class BankVerification
+{
+    /**
+     * @var string value of BankVerificationType
+     */
+    public $type;
+
+    /**
+     * @var string the ID of the front side of the document, as returned when the file was uploaded
+     */
+    public $front;
+}

--- a/lib/Checkout/Accounts/BankVerificationType.php
+++ b/lib/Checkout/Accounts/BankVerificationType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Checkout\Accounts;
+
+/**
+ * The document type accepted as bank verification when onboarding a sub-entity.
+ *
+ * Separate from Common\DocumentType, which lists identity documents (passport, national
+ * identity card, driving license). The API models this one as its own enum whose only
+ * accepted value is bank_statement, so offering it alongside the identity documents would
+ * suggest it is valid where the API rejects it, and vice versa.
+ *
+ * Applies to the EEA, GB and US variants, company and sole trader alike, on schema 2.0
+ * and 3.0. Also separate from InstrumentDocumentType, which happens to carry the same
+ * bank_statement value but belongs to the document on a payment instrument: the spec keeps
+ * the two enums apart and so do we.
+ */
+class BankVerificationType
+{
+    public static $bank_statement = "bank_statement";
+}

--- a/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
+++ b/lib/Checkout/Accounts/OnboardSubEntityDocuments.php
@@ -33,10 +33,10 @@ class OnboardSubEntityDocuments
     public $tax_verification;
 
     /**
-     * Articles of association document.
+     * Memorandum or articles of association document.
      * [Optional] (required for the company full onboarding variants)
      *
-     * @var Document
+     * @var ArticlesOfAssociation
      */
     public $articles_of_association;
 
@@ -44,15 +44,16 @@ class OnboardSubEntityDocuments
      * Shareholder structure document.
      * [Optional] (required for the company full onboarding variants)
      *
-     * @var Document
+     * @var ShareholderStructure
      */
     public $shareholder_structure;
 
     /**
-     * Bank verification document.
-     * [Optional] (required for the EEA company and sole trader full onboarding variants)
+     * Bank verification document: a document showing transactions from the last 3 months.
+     * [Optional] (required for the EEA, GB and US company and sole trader full onboarding
+     * variants)
      *
-     * @var Document
+     * @var BankVerification
      */
     public $bank_verification;
 

--- a/lib/Checkout/Accounts/ShareholderStructure.php
+++ b/lib/Checkout/Accounts/ShareholderStructure.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Checkout\Accounts;
+
+/**
+ * Shareholder structure chart, including the percentage of shares, certified by a competent
+ * authority and dated within the last 3 months.
+ */
+class ShareholderStructure
+{
+    /**
+     * @var string value of ShareholderStructureType
+     */
+    public $type;
+
+    /**
+     * @var string the ID of the front side of the document, as returned when the file was uploaded
+     */
+    public $front;
+}

--- a/lib/Checkout/Accounts/ShareholderStructureType.php
+++ b/lib/Checkout/Accounts/ShareholderStructureType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Checkout\Accounts;
+
+/**
+ * The document type accepted as the shareholder structure when onboarding a sub-entity.
+ *
+ * Separate from Common\DocumentType, which lists identity documents.
+ */
+class ShareholderStructureType
+{
+    public static $certified_shareholder_structure = "certified_shareholder_structure";
+}

--- a/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/OnboardEntityRequestSerializationTest.php
@@ -3,12 +3,18 @@
 namespace Checkout\Tests\Accounts;
 
 use Checkout\Accounts\AgreedTerms;
+use Checkout\Accounts\ArticlesOfAssociation;
+use Checkout\Accounts\ArticlesOfAssociationType;
+use Checkout\Accounts\BankVerification;
+use Checkout\Accounts\BankVerificationType;
 use Checkout\Accounts\CompanyVerification;
 use Checkout\Accounts\Document;
 use Checkout\Accounts\FinancialStatements;
 use Checkout\Accounts\FinancialStatementsType;
 use Checkout\Accounts\OnboardEntityRequest;
 use Checkout\Accounts\OnboardSubEntityDocuments;
+use Checkout\Accounts\ShareholderStructure;
+use Checkout\Accounts\ShareholderStructureType;
 use Checkout\Accounts\TaxVerification;
 use Checkout\JsonSerializer;
 use PHPUnit\Framework\TestCase;
@@ -68,6 +74,9 @@ class OnboardEntityRequestSerializationTest extends TestCase
         }
 
         // identity_verification is a Document (supports back); the others carry type + front only.
+        // articles_of_association, shareholder_structure and bank_verification are their own
+        // classes rather than the generic Document, so this also proves the retyped fields
+        // still serialize to the same JSON.
         $this->assertSame("back_id", $decoded['identity_verification']['back']);
     }
 
@@ -91,9 +100,20 @@ class OnboardEntityRequestSerializationTest extends TestCase
         $taxVerification->front = "file_tax_verification";
         $documents->tax_verification = $taxVerification;
 
-        $documents->articles_of_association = $this->document("articles_of_association", "articles_of_association");
-        $documents->shareholder_structure = $this->document("shareholder_structure", "certified_shareholder_structure");
-        $documents->bank_verification = $this->document("bank_verification", "bank_statement");
+        $articlesOfAssociation = new ArticlesOfAssociation();
+        $articlesOfAssociation->type = ArticlesOfAssociationType::$articles_of_association;
+        $articlesOfAssociation->front = "file_articles_of_association";
+        $documents->articles_of_association = $articlesOfAssociation;
+
+        $shareholderStructure = new ShareholderStructure();
+        $shareholderStructure->type = ShareholderStructureType::$certified_shareholder_structure;
+        $shareholderStructure->front = "file_shareholder_structure";
+        $documents->shareholder_structure = $shareholderStructure;
+
+        $bankVerification = new BankVerification();
+        $bankVerification->type = BankVerificationType::$bank_statement;
+        $bankVerification->front = "file_bank_verification";
+        $documents->bank_verification = $bankVerification;
 
         $financialStatements = new FinancialStatements();
         $financialStatements->type = FinancialStatementsType::$financial_statements;

--- a/test/Checkout/Tests/Accounts/OnboardingDocumentTypeTest.php
+++ b/test/Checkout/Tests/Accounts/OnboardingDocumentTypeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\ArticlesOfAssociationType;
+use Checkout\Accounts\BankVerificationType;
+use Checkout\Accounts\ShareholderStructureType;
+use Checkout\Common\DocumentType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The onboarding document types that had no constants: bank_verification,
+ * articles_of_association and shareholder_structure. All three were typed as the generic
+ * Document, whose docblock points at Common\DocumentType, so a caller following the docblock
+ * looked for these values in the identity enum and concluded they were missing.
+ *
+ * Note bank_statement is also the only accepted payment instrument document type, but the
+ * spec keeps those as two separate enums in two separate places (see InstrumentDocumentType,
+ * added on its own branch). Same value, different enum, kept apart on purpose so a future
+ * change to one does not silently change the other.
+ */
+class OnboardingDocumentTypeTest extends TestCase
+{
+    public function testExposesTheOnboardingDocumentTypes()
+    {
+        $this->assertSame("bank_statement", BankVerificationType::$bank_statement);
+        $this->assertSame("memorandum_of_association", ArticlesOfAssociationType::$memorandum_of_association);
+        $this->assertSame("articles_of_association", ArticlesOfAssociationType::$articles_of_association);
+        $this->assertSame("certified_shareholder_structure", ShareholderStructureType::$certified_shareholder_structure);
+    }
+
+    /**
+     * These belong to their own enums, not to the identity document one. This is the assertion
+     * that stops them being merged into Common\DocumentType the next time someone reports one
+     * of the values as missing from it.
+     */
+    public function testKeepsOnboardingTypesOutOfTheIdentityDocumentType()
+    {
+        $identity = array(
+            DocumentType::$passport,
+            DocumentType::$national_identity_card,
+            DocumentType::$driving_license,
+            DocumentType::$citizen_card,
+            DocumentType::$residence_permit,
+            DocumentType::$electoral_id,
+        );
+
+        $this->assertNotContains("bank_statement", $identity);
+        $this->assertNotContains("articles_of_association", $identity);
+        $this->assertNotContains("certified_shareholder_structure", $identity);
+    }
+}


### PR DESCRIPTION
## What

Models the three onboarding documents that carry a document type, giving each its own class plus type constants: `bank_verification`, `articles_of_association` and `shareholder_structure`.

Reported internally, same merchant as the payment instrument document type: `bank_statement` was missing for `documents.bank_verification.type` on entity onboarding. This is a **different enum in a different place** from the payment instrument one.

## Verified

In the spec: `documents.bank_verification.type` is a single-value enum accepting only `bank_statement`, and it appears on the EEA, GB **and US** variants, company and sole trader alike, on schema 2.0 and 3.0. Not EEA/GB only, as originally reported.

In the code, this is a PHP-only gap: .NET, Java, Python, Ruby and Go all already expose `BankVerificationType`.

## Why it read as "missing"

The field was typed as the generic `Document`, whose docblock says `@var string value of DocumentType`. That is the *identity* document enum (passport, national identity card, driving license). So the docblock itself pointed the caller at the wrong enum. The value was never rejected by the API, it just could not be found where the SDK said to look.

`articles_of_association` and `shareholder_structure` had exactly the same problem and are required on the company full variants, so they were included: the merchant hits them next.

## Approach

Follows the `CompanyVerification` / `CompanyVerificationType` precedent already in `lib/Checkout/Accounts/`.

## Tests

The existing round-trip test now builds the three documents through the new classes, so it proves the retyped fields still serialize to the same JSON. A new test asserts none of the values are in the identity `DocumentType` — that is what stops them being merged into it the next time someone reports one as missing.

898 tests green, lint and code sniffer clean.

## Not breaking

Additive. The three fields were untyped `Document` holders and PHP does not enforce the docblock, so existing code that set `->type` to a literal keeps working unchanged.

Refs INT-1691.