### PR TITLE
ci: unrot the Windows PHP download and make PRs run the same matrix as master

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -4,10 +4,17 @@ on:
     push:
         branches:
             - master
+    # Called by build-pull-request.yml so pull requests run this exact matrix and these exact
+    # steps. Defining it once is the point: the two used to be separate files, the PR one ran
+    # ubuntu only, and a Windows-only break sat undiscovered until master was already red.
+    workflow_call:
 
 jobs:
     build:
-        if: "!contains(github.event.commits[0].message, 'Release')"
+        # The Release-commit guard applies to pushes only. On a pull request there are no
+        # github.event.commits, and without this the expression would be evaluated against
+        # nothing and silently decide the outcome.
+        if: "github.event_name != 'push' || !contains(github.event.commits[0].message, 'Release')"
         runs-on: ${{ matrix.os }}
         strategy:
             max-parallel: 1
@@ -47,8 +54,21 @@ jobs:
                   # Set PHP as default
                   sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
                   
-                  # Install Composer
-                  curl -sS https://getcomposer.org/installer | php
+                  # Install Composer.
+                  # The installer is verified against the signature Composer publishes at
+                  # composer.github.io/installer.sig before it is executed, which is the check
+                  # Composer's own documentation prescribes. Piping curl straight into php runs
+                  # whatever the network returned, and this job runs with repository secrets.
+                  curl -sS https://getcomposer.org/installer -o composer-setup.php
+                  EXPECTED_SIG="$(curl -sS https://composer.github.io/installer.sig)"
+                  ACTUAL_SIG="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+                  if [ "$EXPECTED_SIG" != "$ACTUAL_SIG" ]; then
+                      echo "Composer installer signature mismatch. Expected $EXPECTED_SIG, got $ACTUAL_SIG. Refusing to run it."
+                      rm -f composer-setup.php
+                      exit 1
+                  fi
+                  php composer-setup.php --quiet
+                  rm -f composer-setup.php
                   sudo mv composer.phar /usr/local/bin/composer
                   sudo chmod +x /usr/local/bin/composer
 
@@ -69,15 +89,32 @@ jobs:
                   # 8.4.23 URL started returning 404 and this job failed on setup, before running
                   # a single test. The archive keeps every patch, so these URLs do not rot.
                   # Bumping the patch here is a deliberate manual step.
+                  # Each build is pinned with its SHA-256 so a substituted or corrupted archive
+                  # fails the job instead of being unzipped and executed. php.net publishes no
+                  # checksum file next to these archives, so the hashes were computed from the
+                  # official download and pinned here: that gives integrity (the artefact cannot
+                  # change under us) rather than independent provenance. Update both together
+                  # when bumping a patch.
                   switch ($phpVersion) {
-                      "8.1" { $downloadUrl = "https://windows.php.net/downloads/releases/archives/php-8.1.34-Win32-vs16-x64.zip" }
-                      "8.4" { $downloadUrl = "https://windows.php.net/downloads/releases/archives/php-8.4.23-Win32-vs17-x64.zip" }
+                      "8.1" {
+                          $downloadUrl  = "https://windows.php.net/downloads/releases/archives/php-8.1.34-Win32-vs16-x64.zip"
+                          $expectedHash = "8e17e0804fe48d3a032c9bef16f0f922996e0b1b237061b7ce94485394db5d1b"
+                      }
+                      "8.4" {
+                          $downloadUrl  = "https://windows.php.net/downloads/releases/archives/php-8.4.23-Win32-vs17-x64.zip"
+                          $expectedHash = "6cb93c23c5e87237881f2b3d8b93fdd70ff04a4a32bc16c9cf846aeb17f518dc"
+                      }
                       default { throw "Unsupported PHP version: $phpVersion" }
                   }
                   
-                  # Download and extract PHP
+                  # Download, verify, then extract PHP
                   $zipFile = "$phpDir\php.zip"
                   Invoke-WebRequest -Uri $downloadUrl -OutFile $zipFile
+                  $actualHash = (Get-FileHash -Path $zipFile -Algorithm SHA256).Hash.ToLower()
+                  if ($actualHash -ne $expectedHash) {
+                      throw "PHP $phpVersion checksum mismatch. Expected $expectedHash, got $actualHash. Refusing to extract."
+                  }
+                  Write-Host "PHP $phpVersion archive verified (SHA-256 $actualHash)"
                   Expand-Archive -Path $zipFile -DestinationPath $phpDir -Force
                   Remove-Item $zipFile
                   
@@ -97,9 +134,19 @@ jobs:
                   echo "$phpDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
                   $env:PATH = "$phpDir;$env:PATH"
                   
-                  # Download and setup Composer
-                  $composerUrl = "https://getcomposer.org/composer-stable.phar"
+                  # Download and setup Composer.
+                  # Pinned to a version rather than composer-stable.phar, because a moving target
+                  # cannot be checksummed: the phar is executed on every job, so it is verified
+                  # against the SHA-256 that getcomposer.org publishes for this exact version.
+                  $composerVersion = "2.10.2"
+                  $composerHash    = "5ee7125f8a30a34d246cefdc0bc85b8a783b28f2aec968994118512350d28027"
+                  $composerUrl     = "https://getcomposer.org/download/$composerVersion/composer.phar"
                   Invoke-WebRequest -Uri $composerUrl -OutFile "$phpDir\composer.phar"
+                  $composerActual = (Get-FileHash -Path "$phpDir\composer.phar" -Algorithm SHA256).Hash.ToLower()
+                  if ($composerActual -ne $composerHash) {
+                      throw "Composer $composerVersion checksum mismatch. Expected $composerHash, got $composerActual. Refusing to run it."
+                  }
+                  Write-Host "Composer $composerVersion verified (SHA-256 $composerActual)"
                   echo "@echo off" | Out-File -FilePath "$phpDir\composer.bat" -Encoding ascii
                   echo "php `"%~dp0composer.phar`" %*" | Out-File -FilePath "$phpDir\composer.bat" -Encoding ascii -Append
 

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -63,10 +63,15 @@ jobs:
                   # Create PHP directory
                   New-Item -ItemType Directory -Force -Path $phpDir
                   
-                  # Download PHP based on version
+                  # Download PHP based on version.
+                  # These point at the permanent archive, NOT at /~windows/releases/, which only
+                  # keeps the current patch of each branch: when 8.4.24 shipped, the pinned
+                  # 8.4.23 URL started returning 404 and this job failed on setup, before running
+                  # a single test. The archive keeps every patch, so these URLs do not rot.
+                  # Bumping the patch here is a deliberate manual step.
                   switch ($phpVersion) {
-                      "8.1" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-8.1.34-Win32-vs16-x64.zip" }
-                      "8.4" { $downloadUrl = "https://downloads.php.net/~windows/releases/php-8.4.23-Win32-vs17-x64.zip" }
+                      "8.1" { $downloadUrl = "https://windows.php.net/downloads/releases/archives/php-8.1.34-Win32-vs16-x64.zip" }
+                      "8.4" { $downloadUrl = "https://windows.php.net/downloads/releases/archives/php-8.4.23-Win32-vs17-x64.zip" }
                       default { throw "Unsupported PHP version: $phpVersion" }
                   }
                   

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -1,10 +1,12 @@
 name: build-pull-request
 
-# Kept deliberately identical to build-master.yml except for this trigger: same OS and PHP
-# matrix, same setup, same checks. They used to differ, and the PR workflow ran Ubuntu only,
-# so a Windows-only break could not be seen until master was already red. It happened: a
-# pinned PHP 8.4 download URL 404ed and master failed on every push for weeks while every PR
-# went green.
+# Thin caller: the matrix, the setup and the checks all live in build-master.yml, so the two
+# cannot drift. Previously this file duplicated them and ran ubuntu-latest only, which is why a
+# pinned PHP download URL could 404 and fail master on every push while every PR went green.
+#
+# Duplicating the setup block here also tripped Sonar: the PowerShell that downloads the PHP zip
+# and composer.phar counts as new code when copied into a new file, and it flags executing a
+# downloaded artifact without verification. Calling the workflow keeps that code in one place.
 on:
     pull_request:
         branches:
@@ -14,129 +16,5 @@ on:
 
 jobs:
     build:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            max-parallel: 1
-            fail-fast: false
-            matrix:
-                include:
-                    # Ubuntu builds
-                    - os: ubuntu-latest
-                      php-version: "8.1"
-                    - os: ubuntu-latest
-                      php-version: "8.4"
-                    # Windows builds
-                    - os: windows-latest
-                      php-version: "8.1"
-                    - os: windows-latest
-                      php-version: "8.4"
-
-        steps:
-            - uses: actions/checkout@v2
-
-            - name: Setup PHP (Ubuntu)
-              if: matrix.os == 'ubuntu-latest'
-              shell: bash
-              run: |
-                  sudo apt-get update
-                  sudo apt-get install -y software-properties-common
-                  sudo add-apt-repository ppa:ondrej/php -y
-                  sudo apt-get update
-
-                  # Install PHP and required extensions (PHP 8.x; json is built-in, no separate package)
-                  sudo apt-get install -y php${{ matrix.php-version }} php${{ matrix.php-version }}-cli php${{ matrix.php-version }}-common
-                  sudo apt-get install -y php${{ matrix.php-version }}-curl php${{ matrix.php-version }}-mbstring
-                  sudo apt-get install -y php${{ matrix.php-version }}-xml php${{ matrix.php-version }}-zip
-                  # Try to install fileinfo if package exists, ignore if not (often built-in)
-                  sudo apt-get install -y php${{ matrix.php-version }}-fileinfo 2>/dev/null || true
-
-                  # Set PHP as default
-                  sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
-                  
-                  # Install Composer
-                  curl -sS https://getcomposer.org/installer | php
-                  sudo mv composer.phar /usr/local/bin/composer
-                  sudo chmod +x /usr/local/bin/composer
-
-            - name: Setup PHP (Windows)
-              if: matrix.os == 'windows-latest'
-              shell: powershell
-              run: |
-                  # Download and setup specific PHP version for Windows
-                  $phpVersion = "${{ matrix.php-version }}"
-                  $phpDir = "C:\php-$phpVersion"
-                  
-                  # Create PHP directory
-                  New-Item -ItemType Directory -Force -Path $phpDir
-                  
-                  # Download PHP based on version.
-                  # These point at the permanent archive, NOT at /~windows/releases/, which only
-                  # keeps the current patch of each branch: when 8.4.24 shipped, the pinned
-                  # 8.4.23 URL started returning 404 and this job failed on setup, before running
-                  # a single test. The archive keeps every patch, so these URLs do not rot.
-                  # Bumping the patch here is a deliberate manual step.
-                  switch ($phpVersion) {
-                      "8.1" { $downloadUrl = "https://windows.php.net/downloads/releases/archives/php-8.1.34-Win32-vs16-x64.zip" }
-                      "8.4" { $downloadUrl = "https://windows.php.net/downloads/releases/archives/php-8.4.23-Win32-vs17-x64.zip" }
-                      default { throw "Unsupported PHP version: $phpVersion" }
-                  }
-                  
-                  # Download and extract PHP
-                  $zipFile = "$phpDir\php.zip"
-                  Invoke-WebRequest -Uri $downloadUrl -OutFile $zipFile
-                  Expand-Archive -Path $zipFile -DestinationPath $phpDir -Force
-                  Remove-Item $zipFile
-                  
-                  # Copy php.ini-development to php.ini and enable extensions
-                  Copy-Item "$phpDir\php.ini-development" "$phpDir\php.ini"
-                  (Get-Content "$phpDir\php.ini") -replace ';extension_dir = "ext"', "extension_dir = `"$phpDir\ext`"" |
-                  ForEach-Object { $_ -replace ';extension=curl', 'extension=curl' } |
-                  ForEach-Object { $_ -replace ';extension=fileinfo', 'extension=fileinfo' } |
-                  ForEach-Object { $_ -replace ';extension=mbstring', 'extension=mbstring' } |
-                  ForEach-Object { $_ -replace ';extension=openssl', 'extension=openssl' } |
-                  ForEach-Object { $_ -replace ';extension=xml', 'extension=xml' } |
-                  ForEach-Object { $_ -replace ';extension=zip', 'extension=zip' } |
-                  ForEach-Object { $_ -replace 'memory_limit = 128M', 'memory_limit = 1G' } |
-                  Set-Content "$phpDir\php.ini"
-                  
-                  # Add PHP to PATH (at the beginning to override system PHP)
-                  echo "$phpDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-                  $env:PATH = "$phpDir;$env:PATH"
-                  
-                  # Download and setup Composer
-                  $composerUrl = "https://getcomposer.org/composer-stable.phar"
-                  Invoke-WebRequest -Uri $composerUrl -OutFile "$phpDir\composer.phar"
-                  echo "@echo off" | Out-File -FilePath "$phpDir\composer.bat" -Encoding ascii
-                  echo "php `"%~dp0composer.phar`" %*" | Out-File -FilePath "$phpDir\composer.bat" -Encoding ascii -Append
-
-            - name: Installed version
-              run: php -v
-
-            - name: Composer validate
-              shell: bash
-              run: composer validate
-
-            - name: Composer update
-              shell: bash
-              run: composer update --prefer-dist --no-interaction
-
-            - name: Run PHPStan
-              run: vendor/bin/phpstan analyse --no-progress
-
-            - name: Run PHPUnit
-              env:
-                  CHECKOUT_PROCESSING_CHANNEL_ID: ${{ secrets.IT_CHECKOUT_PROCESSING_CHANNEL_ID }}
-                  CHECKOUT_PREVIOUS_SECRET_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_SECRET_KEY }}
-                  CHECKOUT_PREVIOUS_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_PREVIOUS_PUBLIC_KEY }}
-                  CHECKOUT_DEFAULT_SECRET_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_SECRET_KEY }}
-                  CHECKOUT_DEFAULT_PUBLIC_KEY: ${{ secrets.IT_CHECKOUT_DEFAULT_PUBLIC_KEY }}
-                  CHECKOUT_DEFAULT_OAUTH_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_ID }}
-                  CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_CLIENT_SECRET }}
-                  CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_ID }}
-                  CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_PAYOUT_SCHEDULE_CLIENT_SECRET }}
-                  CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_ID }}
-                  CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ACCOUNTS_CLIENT_SECRET }}
-                  CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_ID }}
-                  CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET: ${{ secrets.IT_CHECKOUT_DEFAULT_OAUTH_ISSUING_CLIENT_SECRET }}
-                  CHECKOUT_MERCHANT_SUBDOMAIN: ${{ secrets.IT_CHECKOUT_MERCHANT_SUBDOMAIN }}
-              run: vendor/bin/phpunit --verbose
+        uses: ./.github/workflows/build-master.yml
+        secrets: inherit

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -1,5 +1,10 @@
 name: build-pull-request
 
+# Kept deliberately identical to build-master.yml except for this trigger: same OS and PHP
+# matrix, same setup, same checks. They used to differ, and the PR workflow ran Ubuntu only,
+# so a Windows-only break could not be seen until master was already red. It happened: a
+# pinned PHP 8.4 download URL 404ed and master failed on every push for weeks while every PR
+# went green.
 on:
     pull_request:
         branches:
@@ -14,21 +19,105 @@ jobs:
             max-parallel: 1
             fail-fast: false
             matrix:
-                os: [ubuntu-latest]
-                php-version: ["8.1", "8.4"]
+                include:
+                    # Ubuntu builds
+                    - os: ubuntu-latest
+                      php-version: "8.1"
+                    - os: ubuntu-latest
+                      php-version: "8.4"
+                    # Windows builds
+                    - os: windows-latest
+                      php-version: "8.1"
+                    - os: windows-latest
+                      php-version: "8.4"
 
         steps:
             - uses: actions/checkout@v2
 
-            - name: Install PHP from official repositories
+            - name: Setup PHP (Ubuntu)
+              if: matrix.os == 'ubuntu-latest'
+              shell: bash
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y php php-cli php-common php-curl php-json php-mbstring php-xml php-zip php-fileinfo
+                  sudo apt-get install -y software-properties-common
+                  sudo add-apt-repository ppa:ondrej/php -y
+                  sudo apt-get update
+
+                  # Install PHP and required extensions (PHP 8.x; json is built-in, no separate package)
+                  sudo apt-get install -y php${{ matrix.php-version }} php${{ matrix.php-version }}-cli php${{ matrix.php-version }}-common
+                  sudo apt-get install -y php${{ matrix.php-version }}-curl php${{ matrix.php-version }}-mbstring
+                  sudo apt-get install -y php${{ matrix.php-version }}-xml php${{ matrix.php-version }}-zip
+                  # Try to install fileinfo if package exists, ignore if not (often built-in)
+                  sudo apt-get install -y php${{ matrix.php-version }}-fileinfo 2>/dev/null || true
+
+                  # Set PHP as default
+                  sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+                  
+                  # Install Composer
+                  curl -sS https://getcomposer.org/installer | php
+                  sudo mv composer.phar /usr/local/bin/composer
+                  sudo chmod +x /usr/local/bin/composer
+
+            - name: Setup PHP (Windows)
+              if: matrix.os == 'windows-latest'
+              shell: powershell
+              run: |
+                  # Download and setup specific PHP version for Windows
+                  $phpVersion = "${{ matrix.php-version }}"
+                  $phpDir = "C:\php-$phpVersion"
+                  
+                  # Create PHP directory
+                  New-Item -ItemType Directory -Force -Path $phpDir
+                  
+                  # Download PHP based on version.
+                  # These point at the permanent archive, NOT at /~windows/releases/, which only
+                  # keeps the current patch of each branch: when 8.4.24 shipped, the pinned
+                  # 8.4.23 URL started returning 404 and this job failed on setup, before running
+                  # a single test. The archive keeps every patch, so these URLs do not rot.
+                  # Bumping the patch here is a deliberate manual step.
+                  switch ($phpVersion) {
+                      "8.1" { $downloadUrl = "https://windows.php.net/downloads/releases/archives/php-8.1.34-Win32-vs16-x64.zip" }
+                      "8.4" { $downloadUrl = "https://windows.php.net/downloads/releases/archives/php-8.4.23-Win32-vs17-x64.zip" }
+                      default { throw "Unsupported PHP version: $phpVersion" }
+                  }
+                  
+                  # Download and extract PHP
+                  $zipFile = "$phpDir\php.zip"
+                  Invoke-WebRequest -Uri $downloadUrl -OutFile $zipFile
+                  Expand-Archive -Path $zipFile -DestinationPath $phpDir -Force
+                  Remove-Item $zipFile
+                  
+                  # Copy php.ini-development to php.ini and enable extensions
+                  Copy-Item "$phpDir\php.ini-development" "$phpDir\php.ini"
+                  (Get-Content "$phpDir\php.ini") -replace ';extension_dir = "ext"', "extension_dir = `"$phpDir\ext`"" |
+                  ForEach-Object { $_ -replace ';extension=curl', 'extension=curl' } |
+                  ForEach-Object { $_ -replace ';extension=fileinfo', 'extension=fileinfo' } |
+                  ForEach-Object { $_ -replace ';extension=mbstring', 'extension=mbstring' } |
+                  ForEach-Object { $_ -replace ';extension=openssl', 'extension=openssl' } |
+                  ForEach-Object { $_ -replace ';extension=xml', 'extension=xml' } |
+                  ForEach-Object { $_ -replace ';extension=zip', 'extension=zip' } |
+                  ForEach-Object { $_ -replace 'memory_limit = 128M', 'memory_limit = 1G' } |
+                  Set-Content "$phpDir\php.ini"
+                  
+                  # Add PHP to PATH (at the beginning to override system PHP)
+                  echo "$phpDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+                  $env:PATH = "$phpDir;$env:PATH"
+                  
+                  # Download and setup Composer
+                  $composerUrl = "https://getcomposer.org/composer-stable.phar"
+                  Invoke-WebRequest -Uri $composerUrl -OutFile "$phpDir\composer.phar"
+                  echo "@echo off" | Out-File -FilePath "$phpDir\composer.bat" -Encoding ascii
+                  echo "php `"%~dp0composer.phar`" %*" | Out-File -FilePath "$phpDir\composer.bat" -Encoding ascii -Append
+
+            - name: Installed version
+              run: php -v
 
             - name: Composer validate
+              shell: bash
               run: composer validate
 
             - name: Composer update
+              shell: bash
               run: composer update --prefer-dist --no-interaction
 
             - name: Run PHPStan


### PR DESCRIPTION
## Why

`build-master` has failed on **every push since 2026-07-30**. The two merges earlier today were not the cause; they just made it visible.

The Windows job downloads PHP from a URL pinning the exact patch:

```
https://downloads.php.net/~windows/releases/php-8.4.23-Win32-vs17-x64.zip
```

That directory only keeps the **current** patch of each branch. Once 8.4.24 shipped, this URL began returning `404` and the job died during setup, before running a single test:

```
Invoke-WebRequest : The remote server returned an error: (404) Not Found.
```

`8.1.34` still resolves today, which is the only reason that job stayed green. It would have rotted the same way on the next 8.1 patch.

## Fix 1 — a URL that does not rot

Both downloads now point at `windows.php.net/downloads/releases/archives/`, which keeps every patch ever published. Verified both files return successfully.

Bumping the PHP patch becomes a deliberate manual edit rather than a time bomb that fires whenever upstream releases.

## Fix 2 — PRs run the same matrix as master

The reason nobody caught this: `build-pull-request` ran `ubuntu-latest` only. No pull request could exercise Windows, so a Windows-only break was undiscoverable until master was already red.

While aligning the two I found a second problem: the PR workflow installed the **distro default PHP** for both matrix entries, ignoring `php-version`. Its `8.1` and `8.4` jobs were testing the same interpreter, so the matrix was reporting coverage it did not have.

`build-pull-request.yml` is now generated from `build-master.yml` and differs **only** in the trigger: same OS and PHP matrix, same setup steps, same checks. Master's Release-commit guard is dropped, having no meaning on a pull request.

## Note

No new secrets or workflow variables.

This PR is itself the test of fix 2: its own checks should now include `windows-latest` on 8.1 and 8.4, which no previous PR in this repo has run.