### PR TITLE
feat(payments): add optional amount to VoidRequest for partial voids

### DIFF
--- a/lib/Checkout/Payments/VoidRequest.php
+++ b/lib/Checkout/Payments/VoidRequest.php
@@ -5,6 +5,13 @@ namespace Checkout\Payments;
 class VoidRequest
 {
     /**
+     * The amount to void. If not specified, the full payment amount is voided.
+     * Min 0, max 9999999999.
+     * @var int
+     */
+    public $amount;
+
+    /**
      * @var string
      */
     public $reference;

--- a/test/Checkout/Tests/Payments/VoidRequestSerializationTest.php
+++ b/test/Checkout/Tests/Payments/VoidRequestSerializationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Checkout\Tests\Payments;
+
+use Checkout\JsonSerializer;
+use Checkout\Payments\VoidRequest;
+use PHPUnit\Framework\TestCase;
+
+class VoidRequestSerializationTest extends TestCase
+{
+    public function testVoidRequestSerializesAmountWhenSet()
+    {
+        $request = new VoidRequest();
+        $request->amount = 100;
+        $request->reference = "partial-void";
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertSame(100, $decoded['amount']);
+        $this->assertSame("partial-void", $decoded['reference']);
+    }
+
+    public function testVoidRequestOmitsAmountWhenUnset()
+    {
+        $request = new VoidRequest();
+        $request->reference = "full-void";
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertArrayNotHasKey('amount', $decoded);
+        $this->assertSame("full-void", $decoded['reference']);
+    }
+}


### PR DESCRIPTION
**Summary**
Adds the optional `amount` field to the payment void request, introduced in the API spec on 2026-08-13. When set, only that amount is voided; when omitted, the full payment amount is voided, exactly as before.

**Changes**
- Void request model: new optional `amount` (integer, min 0, max 9999999999) with doc comment
- Serialization tests: amount present when set, and absent from the body when unset, so existing full-void callers keep sending an identical payload

**API Reference**
- `POST /payments/{id}/voids` (`VoidRequest.amount`)

**Breaking changes**
None.

**README**
No README impact.