### PR TITLE
feat(accounts): add ISV payout schedule fields and payment_instrument_id

### DIFF
--- a/lib/Checkout/Accounts/ScheduleFrequencyDailyRequest.php
+++ b/lib/Checkout/Accounts/ScheduleFrequencyDailyRequest.php
@@ -2,6 +2,10 @@
 
 namespace Checkout\Accounts;
 
+/**
+ * For SaaS sellers (ISV), a daily schedule runs on working days only (monday to friday);
+ * payouts do not take place on weekends.
+ */
 class ScheduleFrequencyDailyRequest extends ScheduleRequest
 {
     public function __construct()

--- a/lib/Checkout/Accounts/ScheduleFrequencyMonthlyRequest.php
+++ b/lib/Checkout/Accounts/ScheduleFrequencyMonthlyRequest.php
@@ -5,6 +5,10 @@ namespace Checkout\Accounts;
 class ScheduleFrequencyMonthlyRequest extends ScheduleRequest
 {
     /**
+     * The day or days of the month the payout should take place.
+     * For SaaS sellers (ISV), only the following combinations are supported,
+     * in any order: [1], [15], [1, 15] or [1, 16].
+     *
      * @var array int
      */
     public $by_month_day;

--- a/lib/Checkout/Accounts/ScheduleFrequencyWeeklyRequest.php
+++ b/lib/Checkout/Accounts/ScheduleFrequencyWeeklyRequest.php
@@ -5,6 +5,10 @@ namespace Checkout\Accounts;
 class ScheduleFrequencyWeeklyRequest extends ScheduleRequest
 {
     /**
+     * The day or days of the week the payout should take place.
+     * For SaaS sellers (ISV), only working days (monday to friday) are supported;
+     * payouts set to take place on weekends are rejected.
+     *
      * @var array values of DaySchedule
      */
     public $by_day;

--- a/lib/Checkout/Accounts/UpdateScheduleRequest.php
+++ b/lib/Checkout/Accounts/UpdateScheduleRequest.php
@@ -15,6 +15,31 @@ class UpdateScheduleRequest
     public $threshold;
 
     /**
+     * The amount, in the minor units of the schedule's currency, to retain in the
+     * sub-entity's available balance. Only funds above the balance_minimum are paid out.
+     * Applies to SaaS seller (ISV) schedules. Defaults to 0 if not set. Minimum value 0.
+     *
+     * @var int
+     */
+    public $balance_minimum;
+
+    /**
+     * Indicates whether to carry forward any balance below the configured minimum
+     * to the next payout. Applies to SaaS seller (ISV) schedules. Defaults to false if not set.
+     *
+     * @var bool
+     */
+    public $carry_forward_enabled;
+
+    /**
+     * The ID of the platforms payment instrument used as the payout destination.
+     * If included, it must reference a verified payment instrument.
+     *
+     * @var string
+     */
+    public $payment_instrument_id;
+
+    /**
      * @var ScheduleRequest
      */
     public $recurrence;

--- a/test/Checkout/Tests/Accounts/UpdateScheduleRequestSerializationTest.php
+++ b/test/Checkout/Tests/Accounts/UpdateScheduleRequestSerializationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Checkout\Tests\Accounts;
+
+use Checkout\Accounts\DaySchedule;
+use Checkout\Accounts\ScheduleFrequencyWeeklyRequest;
+use Checkout\Accounts\UpdateScheduleRequest;
+use Checkout\JsonSerializer;
+use PHPUnit\Framework\TestCase;
+
+class UpdateScheduleRequestSerializationTest extends TestCase
+{
+    public function testSerializesIsvFieldsWhenSet()
+    {
+        $recurrence = new ScheduleFrequencyWeeklyRequest();
+        $recurrence->by_day = [DaySchedule::$MONDAY];
+
+        $request = new UpdateScheduleRequest();
+        $request->enabled = true;
+        $request->threshold = 100;
+        $request->balance_minimum = 500;
+        $request->carry_forward_enabled = true;
+        $request->payment_instrument_id = "ppi_w4jelhppmfiufdnatam37wrfc4";
+        $request->recurrence = $recurrence;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertTrue($decoded['enabled']);
+        $this->assertSame(100, $decoded['threshold']);
+        $this->assertSame(500, $decoded['balance_minimum']);
+        $this->assertTrue($decoded['carry_forward_enabled']);
+        $this->assertSame("ppi_w4jelhppmfiufdnatam37wrfc4", $decoded['payment_instrument_id']);
+        $this->assertSame("weekly", $decoded['recurrence']['frequency']);
+        $this->assertSame(["monday"], $decoded['recurrence']['by_day']);
+    }
+
+    public function testOmitsIsvFieldsWhenUnset()
+    {
+        $request = new UpdateScheduleRequest();
+        $request->enabled = true;
+        $request->threshold = 100;
+
+        $decoded = json_decode((new JsonSerializer())->serialize($request), true);
+
+        $this->assertArrayNotHasKey('balance_minimum', $decoded);
+        $this->assertArrayNotHasKey('carry_forward_enabled', $decoded);
+        $this->assertArrayNotHasKey('payment_instrument_id', $decoded);
+        $this->assertArrayNotHasKey('recurrence', $decoded);
+    }
+}


### PR DESCRIPTION
**Summary**
Adds the 2026-08-05 spec changes: the ISV (SaaS seller) payout schedule fields `balance_minimum` and `carry_forward_enabled`, plus `payment_instrument_id` which was present in the spec but missing from the SDK. Includes characterization tests pinning the payout schedule GET response shape and frequency serialization the API actually uses.

**Changes**
- Payout schedule request/response models: new optional `balance_minimum`, `carry_forward_enabled`, `payment_instrument_id`
- ISV constraints documented on the existing frequency types (working days only for weekly and daily; monthly accepts only [1], [15], [1,15] or [1,16]); no parallel Isv classes because the wire format is identical
- Serialization tests: fields present when set, absent when unset; spec-shape characterization tests

**API Reference**
- `GET /accounts/entities/{id}/payout-schedules`
- `PUT /accounts/entities/{id}/payout-schedules`

**Breaking changes**
None.

**README**
No README impact.